### PR TITLE
New Configuration Properties: groupSearchFilter, connectTimeout  and readTimeout

### DIFF
--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
@@ -225,6 +225,16 @@ public class LdapConfiguration extends AbstractConfiguration {
     private List<LdapName> baseContextsToSynchronizeAsLdapNames;
 
     private Set<LdapName> modifiersNamesToFilterOutAsLdapNames;
+    
+    /**
+     * Used to specify the read timeout for an LDAP operation in milliseconds
+     */
+    private long readTimeout = 0;
+    
+    /**
+     * Used to specify the connect timeout for connecting to the ldap server in milliseconds
+     */
+    private long connectTimeout = 0;
 
     /**
      * {@inheritDoc}
@@ -815,6 +825,32 @@ public class LdapConfiguration extends AbstractConfiguration {
     public void setGroupSearchFilter(String groupSearchFilter) {
         this.groupSearchFilter = groupSearchFilter;
     }
+    
+    @ConfigurationProperty(order = 42, 
+    		displayMessageKey = "readTimeout.display",
+    		helpMessageKey = "readTimeout.help")
+    public long getReadTimeout()
+    {
+    	return readTimeout;
+    }
+    
+    public void setReadTimeout(long readTimeout)
+    {
+    	this.readTimeout = readTimeout;
+    }
+    
+    @ConfigurationProperty(order = 43, 
+    		displayMessageKey = "connectTimeout.display",
+    		helpMessageKey = "connectTimeout.help")
+    public long getConnectTimeout()
+    {
+    	return connectTimeout;
+    }
+    
+    public void setConnectTimeout(long connectTimeout)
+    {
+    	this.connectTimeout = connectTimeout;
+    }
 
     // Getters and setters for configuration properties end here.
     public List<LdapName> getBaseContextsAsLdapNames() {
@@ -922,7 +958,8 @@ public class LdapConfiguration extends AbstractConfiguration {
         builder.append(groupConfig);
         builder.append(retrievePasswordsWithSearch);
         builder.append(groupSearchFilter);
-
+        builder.append(connectTimeout);
+        builder.append(readTimeout);
         return builder;
     }
 

--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
@@ -109,6 +109,11 @@ public class LdapConfiguration extends AbstractConfiguration {
      * A search filter that any account needs to match in order to be returned.
      */
     private String accountSearchFilter = null;
+    
+    /**
+     * A search filter that any group needs to match in order to be returned
+     */
+    private String groupSearchFilter = null;
 
     /**
      * The LDAP attribute holding the member for non-POSIX static groups.
@@ -799,6 +804,17 @@ public class LdapConfiguration extends AbstractConfiguration {
     public void setDnAttribute(String dnAttribute) {
         this.dnAttribute = dnAttribute;
     }
+    
+    @ConfigurationProperty(order = 41,
+            displayMessageKey = "groupSearchFilter.display",
+            helpMessageKey = "groupSearchFilter.help")
+    public String getGroupSearchFilter() {
+        return groupSearchFilter;
+    }
+
+    public void setGroupSearchFilter(String groupSearchFilter) {
+        this.groupSearchFilter = groupSearchFilter;
+    }
 
     // Getters and setters for configuration properties end here.
     public List<LdapName> getBaseContextsAsLdapNames() {
@@ -905,6 +921,8 @@ public class LdapConfiguration extends AbstractConfiguration {
         builder.append(accountConfig);
         builder.append(groupConfig);
         builder.append(retrievePasswordsWithSearch);
+        builder.append(groupSearchFilter);
+
         return builder;
     }
 

--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapConnection.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapConnection.java
@@ -32,10 +32,12 @@ import static org.identityconnectors.common.CollectionUtil.newCaseInsensitiveSet
 import static org.identityconnectors.common.StringUtil.isNotBlank;
 
 import com.sun.jndi.ldap.ctl.PasswordExpiredResponseControl;
+
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Set;
+
 import javax.naming.AuthenticationException;
 import javax.naming.Context;
 import javax.naming.NamingException;
@@ -43,10 +45,13 @@ import javax.naming.directory.Attributes;
 import javax.naming.ldap.Control;
 import javax.naming.ldap.InitialLdapContext;
 import javax.naming.ldap.LdapContext;
+
+import net.tirasa.connid.bundles.ldap.commons.LdapConstants;
 import net.tirasa.connid.bundles.ldap.commons.LdapNativeSchema;
 import net.tirasa.connid.bundles.ldap.commons.ServerNativeSchema;
 import net.tirasa.connid.bundles.ldap.commons.StaticNativeSchema;
 import net.tirasa.connid.bundles.ldap.schema.LdapSchemaMapping;
+
 import org.identityconnectors.common.Pair;
 import org.identityconnectors.common.logging.Log;
 import org.identityconnectors.common.security.GuardedString;
@@ -149,7 +154,9 @@ public class LdapConnection {
         env.put(Context.INITIAL_CONTEXT_FACTORY, LDAP_CTX_FACTORY);
         env.put(Context.PROVIDER_URL, getLdapUrls());
         env.put(Context.REFERRAL, "follow");
-
+        env.put(LdapConstants.CONNECT_TIMEOUT_ENV_PROP, Long.toString(config.getConnectTimeout()));
+        env.put(LdapConstants.READ_TIMEOUT_ENV_PROP, Long.toString(config.getReadTimeout()));
+        
         if (config.isSsl()) {
             env.put(Context.SECURITY_PROTOCOL, "ssl");
         }

--- a/src/main/java/net/tirasa/connid/bundles/ldap/commons/LdapConstants.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/commons/LdapConstants.java
@@ -43,7 +43,11 @@ public class LdapConstants {
     public static final String SEARCH_FILTER_NAME = "searchFilter";
 
     public static final String OP_SEARCH_FILTER = "searchFilter";
-
+    
+    public static final String CONNECT_TIMEOUT_ENV_PROP = "com.sun.jndi.ldap.connect.timeout";
+    
+    public static final String READ_TIMEOUT_ENV_PROP = "com.sun.jndi.ldap.read.timeout";
+    
     /**
      * Overrides the framework-defined password because ours is readable:
      * we can return the password from <code>sync()</code> when doing

--- a/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapSearch.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapSearch.java
@@ -212,12 +212,15 @@ public class LdapSearch {
         controls.setSearchScope(searchScope);
 
         String optionsFilter = LdapConstants.getSearchFilter(options);
-        String userFilter = null;
+        String searchFilter = null;
         if (oclass.equals(ObjectClass.ACCOUNT)) {
-            userFilter = conn.getConfiguration().getAccountSearchFilter();
+            searchFilter = conn.getConfiguration().getAccountSearchFilter();
+        }
+        else if(oclass.equals(ObjectClass.GROUP)) {
+        	searchFilter = conn.getConfiguration().getGroupSearchFilter();
         }
         String nativeFilter = filter != null ? filter.getNativeFilter() : null;
-        return new LdapInternalSearch(conn, getSearchFilter(optionsFilter, nativeFilter, userFilter),
+        return new LdapInternalSearch(conn, getSearchFilter(optionsFilter, nativeFilter, searchFilter),
                 dns, strategy, controls);
     }
 

--- a/src/main/resources/net/tirasa/connid/bundles/ldap/Messages.properties
+++ b/src/main/resources/net/tirasa/connid/bundles/ldap/Messages.properties
@@ -106,6 +106,10 @@ dnAttribute.display=Entry DN attribute name
 dnAttribute.help=Entry DN attribute name (default: entryDN)
 groupSearchFilter.display=LDAP Filter for Retrieving Groups
 groupSearchFilter.help=An optional LDAP filter to control which groups are returned from the LDAP resource. If no filter is specified, only groups that include all specified object classes are returned.
+connectTimeout.display=Connection Timeout (Milliseconds)
+connectTimeout.help=Time to wait when opening new server connections. Value of 0 means the TCP network timeout will be used, which may be several minutes. Also, Value 0 or less than 0 means there is no limit.
+readTimeout.display=Read Timeout (Milliseconds)
+readTimeout.help=Time to wait for a response to be received. If there is no response within the specified time period, the read attempt will be aborted. Value 0 or less than 0 means there is no limit.
 
 # Configuration properties validation.
 host.notBlank=The host cannot be blank

--- a/src/main/resources/net/tirasa/connid/bundles/ldap/Messages.properties
+++ b/src/main/resources/net/tirasa/connid/bundles/ldap/Messages.properties
@@ -104,6 +104,8 @@ groupNameAttributes.help=Attribute or attributes which holds the group''s name. 
 
 dnAttribute.display=Entry DN attribute name
 dnAttribute.help=Entry DN attribute name (default: entryDN)
+groupSearchFilter.display=LDAP Filter for Retrieving Groups
+groupSearchFilter.help=An optional LDAP filter to control which groups are returned from the LDAP resource. If no filter is specified, only groups that include all specified object classes are returned.
 
 # Configuration properties validation.
 host.notBlank=The host cannot be blank

--- a/src/test/java/net/tirasa/connid/bundles/ldap/LdapConfigurationTests.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/LdapConfigurationTests.java
@@ -319,6 +319,7 @@ public class LdapConfigurationTests {
         assertNull(config.getPasswordAttributeToSynchronize());
         assertNull(config.getPasswordDecryptionKey());
         assertNull(config.getPasswordDecryptionInitializationVector());
+        assertNull(config.getGroupSearchFilter());
     }
 
     private static void assertCanValidate(LdapConfiguration config) {

--- a/src/test/java/net/tirasa/connid/bundles/ldap/LdapConfigurationTests.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/LdapConfigurationTests.java
@@ -320,6 +320,8 @@ public class LdapConfigurationTests {
         assertNull(config.getPasswordDecryptionKey());
         assertNull(config.getPasswordDecryptionInitializationVector());
         assertNull(config.getGroupSearchFilter());
+        assertEquals(0, config.getReadTimeout());
+        assertEquals(0, config.getConnectTimeout());
     }
 
     private static void assertCanValidate(LdapConfiguration config) {


### PR DESCRIPTION
https://connid.atlassian.net/browse/LDAP-17  
Same as accountsearchfilter groupsearch filter considers only those groups that match the specified filter.

groupSearchFilter String LDAP search filter for Groups. When searching for groups, the connector only considers those groups that match the specified filter.

Please review the changelist. Also help me in adding labels for other languages.
