### PR TITLE
Automatic DN generation for creating accounts & groups using friendly name

### DIFF
--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
@@ -31,14 +31,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
+
 import net.tirasa.connid.bundles.ldap.commons.LdapConstants;
-
 import static net.tirasa.connid.bundles.ldap.commons.LdapUtil.nullAsEmpty;
-
 import net.tirasa.connid.bundles.ldap.commons.ObjectClassMappingConfig;
-
 import static org.identityconnectors.common.CollectionUtil.newList;
 
 import org.identityconnectors.common.EqualsHashCodeBuilder;
@@ -52,6 +51,7 @@ import org.identityconnectors.framework.common.exceptions.ConfigurationException
 import org.identityconnectors.framework.common.objects.ObjectClass;
 import org.identityconnectors.framework.spi.AbstractConfiguration;
 import org.identityconnectors.framework.spi.ConfigurationProperty;
+import org.identityconnectors.framework.spi.operations.CreateOp;
 import org.identityconnectors.framework.spi.operations.SyncOp;
 
 /**
@@ -206,6 +206,28 @@ public class LdapConfiguration extends AbstractConfiguration {
      * Whether to retrieve passwords when searching. The default is "false".
      */
     private boolean retrievePasswordsWithSearch;
+    
+    /**
+     * The RDN to use while generating new user account DN.
+     */
+    private String userRDNAttribute;
+    
+    /**
+     * The User Container DN will be appended to the user RDN attribute to construct the DN while creating an account.
+     * During create if the username is not a valid DN this attribute value will be used to construct the DN.
+     */
+    private String userCreateContainerDN;
+    
+    /**
+     * The RDN to use while generating new group DN.
+     */
+    private String groupRDNAttribute;
+    
+    /**
+     * The Group Container DN will be appended to the group RDN attribute to construct the DN while creating an group. 
+     * During create if the groupname is not a valid DN this attribute value will be used to construct the DN.
+     */
+    private String groupCreateContainerDN;
 
     // Other state.
     private final ObjectClassMappingConfig accountConfig = new ObjectClassMappingConfig(
@@ -301,6 +323,13 @@ public class LdapConfiguration extends AbstractConfiguration {
             checkNotBlank(passwordDecryptionKey, "decryptionKey.notBlank");
             checkNotBlank(passwordDecryptionInitializationVector, "decryptionInitializationVector.notBlank");
         }
+        
+        if(userCreateContainerDN != null && userCreateContainerDN.trim().length() == 0)
+        	checkNoInvalidLdapNames(new String[]{userCreateContainerDN}, "userCreateContainerDN.noInvalidLdapName");
+        
+        if(groupCreateContainerDN != null && groupCreateContainerDN.trim().length() == 0)
+        	checkNoInvalidLdapNames(new String[]{groupCreateContainerDN}, "groupCreateContainerDN.noInvalidLdapName");      
+        
     }
 
     private void checkNotBlank(String value, String errorMessage) {
@@ -851,6 +880,46 @@ public class LdapConfiguration extends AbstractConfiguration {
     {
     	this.connectTimeout = connectTimeout;
     }
+    
+    @ConfigurationProperty(order = 44, displayMessageKey = "userRDNAttribute.display",
+            helpMessageKey = "userRDNAttribute.help", operations ={CreateOp.class})
+	public String getUserRDNAttribute() {
+		return userRDNAttribute;
+	}
+
+	public void setUserRDNAttribute(String userRDNAttribute) {
+		this.userRDNAttribute = userRDNAttribute;
+	}
+	
+	@ConfigurationProperty(order = 45, displayMessageKey = "groupRDNAttribute.display",
+            helpMessageKey = "groupRDNAttribute.help", operations ={CreateOp.class})
+	public String getGroupRDNAttribute() {
+		return groupRDNAttribute;
+	}
+
+	public void setGroupRDNAttribute(String groupRDNAttribute) {
+		this.groupRDNAttribute = groupRDNAttribute;
+	}
+
+    @ConfigurationProperty(order = 46, displayMessageKey = "userCreateContainerDN.display",
+            helpMessageKey = "userCreateContainerDN.help", operations ={CreateOp.class})
+	public String getUserCreateContainerDN() {
+		return userCreateContainerDN;
+	}
+
+	public void setUserCreateContainerDN(String userCreateContainerDN) {
+		this.userCreateContainerDN = userCreateContainerDN;
+	}
+
+    @ConfigurationProperty(order = 47, displayMessageKey = "groupCreateContainerDN.display",
+            helpMessageKey = "groupCreateContainerDN.help", operations ={CreateOp.class})
+	public String getGroupCreateContainerDN() {
+		return groupCreateContainerDN;
+	}
+
+	public void setGroupCreateContainerDN(String groupCreateContainerDN) {
+		this.groupCreateContainerDN = groupCreateContainerDN;
+	}
 
     // Getters and setters for configuration properties end here.
     public List<LdapName> getBaseContextsAsLdapNames() {
@@ -960,6 +1029,10 @@ public class LdapConfiguration extends AbstractConfiguration {
         builder.append(groupSearchFilter);
         builder.append(connectTimeout);
         builder.append(readTimeout);
+        builder.append(userRDNAttribute);
+        builder.append(groupRDNAttribute);
+        builder.append(userCreateContainerDN);
+        builder.append(groupCreateContainerDN);
         return builder;
     }
 

--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
@@ -324,10 +324,10 @@ public class LdapConfiguration extends AbstractConfiguration {
             checkNotBlank(passwordDecryptionInitializationVector, "decryptionInitializationVector.notBlank");
         }
         
-        if(userCreateContainerDN != null && userCreateContainerDN.trim().length() == 0)
+        if(userCreateContainerDN != null && userCreateContainerDN.trim().length() != 0)
         	checkNoInvalidLdapNames(new String[]{userCreateContainerDN}, "userCreateContainerDN.noInvalidLdapName");
         
-        if(groupCreateContainerDN != null && groupCreateContainerDN.trim().length() == 0)
+        if(groupCreateContainerDN != null && groupCreateContainerDN.trim().length() != 0)
         	checkNoInvalidLdapNames(new String[]{groupCreateContainerDN}, "groupCreateContainerDN.noInvalidLdapName");      
         
     }

--- a/src/main/resources/net/tirasa/connid/bundles/ldap/Messages.properties
+++ b/src/main/resources/net/tirasa/connid/bundles/ldap/Messages.properties
@@ -110,6 +110,14 @@ connectTimeout.display=Connection Timeout (Milliseconds)
 connectTimeout.help=Time to wait when opening new server connections. Value of 0 means the TCP network timeout will be used, which may be several minutes. Also, Value 0 or less than 0 means there is no limit.
 readTimeout.display=Read Timeout (Milliseconds)
 readTimeout.help=Time to wait for a response to be received. If there is no response within the specified time period, the read attempt will be aborted. Value 0 or less than 0 means there is no limit.
+userRDNAttribute.display=User RDN Attribute
+userRDNAttribute.help=The RDN to use while generating new user account DN.
+groupRDNAttribute.display=Group RDN Attribute
+groupRDNAttribute.help=The RDN to use while generating new group DN.
+userCreateContainerDN.display=User DN
+userCreateContainerDN.help=The User Container DN will be appended to the user RDN attribute to construct the DN while creating an account. During create if the user name is not a valid DN this attribute value will be used to construct the DN. 
+GroupCreateContainerDN.display=Group DN
+GroupCreateContainerDN.help=The Group Container DN will be appended to the group RDN attribute to construct the DN while creating an group. During create if the group name is not a valid DN this attribute value will be used to construct the DN.
 
 # Configuration properties validation.
 host.notBlank=The host cannot be blank
@@ -142,6 +150,8 @@ changeLogBlockSize.legalValue=The synchronization block size should be greather 
 passwordAttributeToSynchronize.notBlank=The password attribute to synchronize cannot be blank
 decryptionKey.notBlank=The decryption key cannot be blank
 decryptionInitializationVector.notBlank=The decryption initialization vector cannot be blank
+userCreateContainerDN.noInvalidLdapName=The user create container DN {0} cannot be parsed
+groupCreateContainerDN.noInvalidLdapName=The group create container DN {0} cannot be parsed
 
 entryNotFound=Entry "{0}" not found
 readingPasswordsNotSupported=Returning passwords from a search operation is not supported

--- a/src/test/java/net/tirasa/connid/bundles/ldap/LdapConfigurationTests.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/LdapConfigurationTests.java
@@ -24,6 +24,7 @@
 package net.tirasa.connid.bundles.ldap;
 
 import net.tirasa.connid.bundles.ldap.LdapConfiguration;
+
 import java.util.Arrays;
 
 import static org.identityconnectors.common.CollectionUtil.newList;
@@ -44,6 +45,9 @@ import org.junit.Test;
 public class LdapConfigurationTests {
 
     private static final String INVALID_DN = "dc=a,,";
+    private static final String VALID_USER_DN = "ou=users, dc=example,dc=com";
+    private static final String VALID_GROUP_DN = "ou=groups, dc=example,dc=com";
+    public static final String ACME_USERS_DN_SPECIAL = "ou=Users,hola,o=Acme,dc=example,dc=com";
 
     private LdapConfiguration config;
 
@@ -279,6 +283,41 @@ public class LdapConfigurationTests {
         config.setPasswordDecryptionInitializationVector(new GuardedByteArray(new byte[0]));
         config.validate();
     }
+    
+    @Test(expected = ConfigurationException.class)
+    public void testInvalidUserContainerDN()
+    {
+    	config.setUserCreateContainerDN(INVALID_DN);
+    	config.validate();
+    }
+    
+    @Test
+    public void testValidUserContainerDN()
+    {
+    	config.setUserCreateContainerDN(VALID_USER_DN);
+    	config.validate();
+    }
+    
+    @Test
+    public void testValidUserContainerDNSpecialChar()
+    {
+    	config.setUserCreateContainerDN(ACME_USERS_DN_SPECIAL);
+    	config.validate();
+    }
+    
+    @Test(expected = ConfigurationException.class)
+    public void testInvalidGroupContainerDN()
+    {
+    	config.setGroupCreateContainerDN(INVALID_DN);
+    	config.validate();
+    } 
+    
+    @Test
+    public void testValidGroupContainerDN()
+    {
+    	config.setGroupCreateContainerDN(VALID_GROUP_DN);
+    	config.validate();
+    }
 
     @Test
     public void testDefaultValues() {
@@ -322,6 +361,10 @@ public class LdapConfigurationTests {
         assertNull(config.getGroupSearchFilter());
         assertEquals(0, config.getReadTimeout());
         assertEquals(0, config.getConnectTimeout());
+        assertNull(config.getUserRDNAttribute());
+        assertNull(config.getGroupRDNAttribute());
+        assertNull(config.getUserCreateContainerDN());
+        assertNull(config.getGroupCreateContainerDN());
     }
 
     private static void assertCanValidate(LdapConfiguration config) {

--- a/src/test/java/net/tirasa/connid/bundles/ldap/LdapConfigurationTests.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/LdapConfigurationTests.java
@@ -298,7 +298,7 @@ public class LdapConfigurationTests {
     	config.validate();
     }
     
-    @Test
+    @Test(expected=ConfigurationException.class)
     public void testValidUserContainerDNSpecialChar()
     {
     	config.setUserCreateContainerDN(ACME_USERS_DN_SPECIAL);

--- a/src/test/java/net/tirasa/connid/bundles/ldap/LdapConnectorTestBase.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/LdapConnectorTestBase.java
@@ -75,6 +75,8 @@ public abstract class LdapConnectorTestBase {
     public static final String CZECH_REPUBLIC_C = "Czech Republic";
 
     public static final String ACME_USERS_DN = "ou=Users,o=Acme,dc=example,dc=com";
+    
+    public static final String ACME_GROUPS_DN = "ou=groups,o=Acme,dc=example,dc=com";
 
     public static final String BUGS_BUNNY_DN = "uid=bugs.bunny,ou=Users,o=Acme,dc=example,dc=com";
 
@@ -139,6 +141,8 @@ public abstract class LdapConnectorTestBase {
     public static final String USER_0_SN = "Amar";
 
     public static final String USER_0_GIVEN_NAME = "Aaccf";
+    
+    public static final String NAME_WITH_COMMA = "Pavan, Kumar";
 
     // Cf. test/opends/config/config.ldif and setup-test-opends.xml.
     private static final String[] FILES = {

--- a/src/test/java/net/tirasa/connid/bundles/ldap/modify/LdapCreateTests.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/modify/LdapCreateTests.java
@@ -301,7 +301,7 @@ public class LdapCreateTests extends LdapConnectorTestBase {
         doCreateAccount(newFacade(config), new OperationOptionsBuilder().setAttributesToGet("givenName").build());
     }
     
-    @Test(expected = ConnectorException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void testUserRDNWithNameAsNotDN()
     {
     	LdapConfiguration configuration = newConfiguration();
@@ -359,7 +359,7 @@ public class LdapCreateTests extends LdapConnectorTestBase {
     	assertEquals(created.getUidValue(), obj.getUid().getUidValue());    	 
     }
     
-    @Test(expected = ConnectorException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void testGroupRDNWithNameAsNotDN()
     {
 		LdapConfiguration configuration = newConfiguration();

--- a/src/test/java/net/tirasa/connid/bundles/ldap/modify/LdapCreateTests.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/modify/LdapCreateTests.java
@@ -301,7 +301,7 @@ public class LdapCreateTests extends LdapConnectorTestBase {
         doCreateAccount(newFacade(config), new OperationOptionsBuilder().setAttributesToGet("givenName").build());
     }
     
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testUserRDNWithNameAsNotDN()
     {
     	LdapConfiguration configuration = newConfiguration();


### PR DESCRIPTION
If userRDNAttribute and userCreateContainerDN are specified for creating
a user using friendly username UserDN will be computed as <User RDN
Attribute>=<username>,<userCreateContainerDN>. Same as for group need to
specify groupRDNAttribute and GroupCreateContainerDN. If RDN attribute
is specified alone and single base context is present DN will be
generated as <RDN attribute>=<value>, <single BASE DN>.

Specifying RDN attribute and having multiple base context and trying to
create a user using user friendly name results in error.

Please review and let me know for any changes