### PR TITLE
[LDAP-39] Correct usage of ALL special class to ANY

### DIFF
--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
@@ -36,6 +36,7 @@ import javax.naming.ldap.LdapName;
 import net.tirasa.connid.bundles.ldap.commons.LdapConstants;
 import net.tirasa.connid.bundles.ldap.commons.LdapUtil;
 import net.tirasa.connid.bundles.ldap.commons.ObjectClassMappingConfig;
+import net.tirasa.connid.bundles.ldap.schema.LdapSchemaMapping;
 import net.tirasa.connid.bundles.ldap.search.DefaultSearchStrategy;
 import org.identityconnectors.common.CollectionUtil;
 import org.identityconnectors.common.EqualsHashCodeBuilder;
@@ -244,6 +245,11 @@ public class LdapConfiguration extends AbstractConfiguration {
             CollectionUtil.newList("top", "groupOfUniqueNames"),
             false, CollectionUtil.newList("cn"));
 
+    private final ObjectClassMappingConfig anyObjectConfig = new ObjectClassMappingConfig(
+            LdapSchemaMapping.ANY_OBJECT_CLASS, 
+            CollectionUtil.newList("top"),
+            false, CollectionUtil.newList(DEFAULT_ID_ATTRIBUTE));
+
     private final ObjectClassMappingConfig allConfig = new ObjectClassMappingConfig(
             ObjectClass.ALL,
             CollectionUtil.newList("top"),
@@ -295,11 +301,11 @@ public class LdapConfiguration extends AbstractConfiguration {
         checkNotEmpty(groupConfig.getShortNameLdapAttributes(), "groupNameAttributes.notEmpty");
         checkNoBlankValues(groupConfig.getShortNameLdapAttributes(), "groupNameAttributes.noBlankValues");
 
-        checkNotEmpty(allConfig.getLdapClasses(), "anyObjectClasses.notEmpty");
-        checkNoBlankValues(allConfig.getLdapClasses(), "anyObjectClasses.noBlankValues");
+        checkNotEmpty(anyObjectConfig.getLdapClasses(), "anyObjectClasses.notEmpty");
+        checkNoBlankValues(anyObjectConfig.getLdapClasses(), "anyObjectClasses.noBlankValues");
 
-        checkNotEmpty(allConfig.getShortNameLdapAttributes(), "anyObjectNameAttributes.notEmpty");
-        checkNoBlankValues(allConfig.getShortNameLdapAttributes(), "anyObjectNameAttributes.noBlankValues");
+        checkNotEmpty(anyObjectConfig.getShortNameLdapAttributes(), "anyObjectNameAttributes.notEmpty");
+        checkNoBlankValues(anyObjectConfig.getShortNameLdapAttributes(), "anyObjectNameAttributes.noBlankValues");
 
         checkNotBlank(getUserSearchScope(), "userSearchScope.notBlank");
         checkValidScope(getUserSearchScope(), "userSearchScope.invalidScope");
@@ -641,24 +647,24 @@ public class LdapConfiguration extends AbstractConfiguration {
             displayMessageKey = "anyObjectClasses.display",
             helpMessageKey = "anyObjectClasses.help")
     public String[] getAnyObjectClasses() {
-        List<String> ldapClasses = allConfig.getLdapClasses();
+        List<String> ldapClasses = anyObjectConfig.getLdapClasses();
         return ldapClasses.toArray(new String[ldapClasses.size()]);
     }
 
     public void setAnyObjectClasses(String... anyObjectClasses) {
-        allConfig.setLdapClasses(Arrays.asList(anyObjectClasses));
+        anyObjectConfig.setLdapClasses(Arrays.asList(anyObjectClasses));
     }
 
     @ConfigurationProperty(order = 21,
             displayMessageKey = "anyObjectNameAttributes.display",
             helpMessageKey = "anyObjectNameAttributes.help")
     public String[] getAnyObjectNameAttributes() {
-        List<String> shortNameLdapAttributes = allConfig.getShortNameLdapAttributes();
+        List<String> shortNameLdapAttributes = anyObjectConfig.getShortNameLdapAttributes();
         return shortNameLdapAttributes.toArray(new String[shortNameLdapAttributes.size()]);
     }
 
     public void setAnyObjectNameAttributes(String... anyObjectNameAttributes) {
-        allConfig.setShortNameLdapAttributes(Arrays.asList(anyObjectNameAttributes));
+        anyObjectConfig.setShortNameLdapAttributes(Arrays.asList(anyObjectNameAttributes));
     }
 
     @ConfigurationProperty(order = 22,
@@ -1025,6 +1031,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         Map<ObjectClass, ObjectClassMappingConfig> result = new HashMap<ObjectClass, ObjectClassMappingConfig>();
         result.put(accountConfig.getObjectClass(), accountConfig);
         result.put(groupConfig.getObjectClass(), groupConfig);
+        result.put(anyObjectConfig.getObjectClass(), anyObjectConfig);
         result.put(allConfig.getObjectClass(), allConfig);
         return result;
     }

--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
@@ -246,7 +246,7 @@ public class LdapConfiguration extends AbstractConfiguration {
             false, CollectionUtil.newList("cn"));
 
     private final ObjectClassMappingConfig anyObjectConfig = new ObjectClassMappingConfig(
-            LdapSchemaMapping.ANY_OBJECT_CLASS, 
+            LdapSchemaMapping.ANY_OBJECT_CLASS,
             CollectionUtil.newList("top"),
             false, CollectionUtil.newList(DEFAULT_ID_ATTRIBUTE));
 

--- a/src/main/java/net/tirasa/connid/bundles/ldap/schema/LdapSchemaMapping.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/schema/LdapSchemaMapping.java
@@ -123,9 +123,6 @@ public class LdapSchemaMapping {
      * Returns the LDAP object classes to which the given framework object class is mapped.
      */
     public List<String> getLdapClasses(ObjectClass oclass) {
-        if (oclass.equals(ANY_OBJECT_CLASS)) {
-            return Collections.<String>emptyList();
-        }
         ObjectClassMappingConfig oclassConfig = conn.getConfiguration().
                 getObjectClassMappingConfigs().get(oclass);
         if (oclassConfig != null) {
@@ -220,7 +217,7 @@ public class LdapSchemaMapping {
             clazz = oclass;
             idAttribute = conn.getConfiguration().getUidAttribute();
         } else {
-            clazz = ObjectClass.ALL;
+            clazz = oclass.equals(ANY_OBJECT_CLASS) ? oclass : ObjectClass.ALL;
             idAttribute = null;
         }
 

--- a/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapSearch.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapSearch.java
@@ -40,7 +40,6 @@ import net.tirasa.connid.bundles.ldap.commons.LdapConstants;
 import net.tirasa.connid.bundles.ldap.commons.LdapEntry;
 import net.tirasa.connid.bundles.ldap.commons.LdapUtil;
 import net.tirasa.connid.bundles.ldap.commons.StatusManagement;
-import net.tirasa.connid.bundles.ldap.schema.LdapSchemaMapping;
 import org.identityconnectors.common.CollectionUtil;
 import org.identityconnectors.common.StringUtil;
 import org.identityconnectors.common.logging.Log;

--- a/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapSearch.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapSearch.java
@@ -87,9 +87,6 @@ public class LdapSearch {
     private final ResultsHandler handler;
 
     public static Set<String> getAttributesReturnedByDefault(final LdapConnection conn, final ObjectClass oclass) {
-        if (oclass.equals(LdapSchemaMapping.ANY_OBJECT_CLASS)) {
-            return CollectionUtil.newSet(Name.NAME);
-        }
         Set<String> result = CollectionUtil.newCaseInsensitiveSet();
         ObjectClassInfo oci = conn.getSchemaMapping().schema().findObjectClassInfo(oclass.getObjectClassValue());
         if (oci != null) {

--- a/src/test/java/net/tirasa/connid/bundles/ldap/modify/LdapCreateTests.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/modify/LdapCreateTests.java
@@ -239,7 +239,6 @@ public class LdapCreateTests extends LdapConnectorTestBase {
 
     }
 
-
     @Test
     public void createBinaryAttributes() throws IOException {
         ConnectorFacade facade = newFacade();

--- a/src/test/java/net/tirasa/connid/bundles/ldap/modify/LdapCreateTests.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/modify/LdapCreateTests.java
@@ -182,7 +182,7 @@ public class LdapCreateTests extends LdapConnectorTestBase {
         assertFalse(config.getUidAttribute().equalsIgnoreCase("entryDN"));
         config.setUidAttribute("entryDN");
         config.setGidAttribute("entryDN");
-        config.setAnyObjectNameAttributes("cn");
+        config.setAnyObjectNameAttributes("o");
         config.setBaseContexts(SMALL_COMPANY_DN);
         config.setAnyObjectClasses("top", "organization");
         ConnectorFacade facade = newFacade(config);

--- a/src/test/java/net/tirasa/connid/bundles/ldap/modify/LdapCreateTests.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/modify/LdapCreateTests.java
@@ -46,6 +46,8 @@ import org.identityconnectors.framework.common.objects.Uid;
 import net.tirasa.connid.bundles.ldap.LdapConfiguration;
 import net.tirasa.connid.bundles.ldap.LdapConnectorTestBase;
 import net.tirasa.connid.bundles.ldap.MyStatusManagement;
+import net.tirasa.connid.bundles.ldap.schema.LdapSchemaMapping;
+
 import org.identityconnectors.framework.common.objects.OperationOptions;
 import org.junit.jupiter.api.Test;
 
@@ -158,6 +160,7 @@ public class LdapCreateTests extends LdapConnectorTestBase {
     public void createArbitrary() {
         LdapConfiguration config = newConfiguration();
         config.setBaseContexts(SMALL_COMPANY_DN);
+        config.setAnyObjectClasses("top", "organization");
         ConnectorFacade facade = newFacade(config);
 
         doCreateArbitrary(facade);
@@ -167,6 +170,7 @@ public class LdapCreateTests extends LdapConnectorTestBase {
     public void createArbitraryWhenReadingSchema() {
         LdapConfiguration config = newConfiguration(true);
         config.setBaseContexts(SMALL_COMPANY_DN);
+        config.setAnyObjectClasses("top", "organization");
         ConnectorFacade facade = newFacade(config);
 
         doCreateArbitrary(facade);
@@ -178,7 +182,9 @@ public class LdapCreateTests extends LdapConnectorTestBase {
         assertFalse(config.getUidAttribute().equalsIgnoreCase("entryDN"));
         config.setUidAttribute("entryDN");
         config.setGidAttribute("entryDN");
+        config.setAnyObjectNameAttributes("cn");
         config.setBaseContexts(SMALL_COMPANY_DN);
+        config.setAnyObjectClasses("top", "organization");
         ConnectorFacade facade = newFacade(config);
 
         doCreateArbitrary(facade);
@@ -190,29 +196,29 @@ public class LdapCreateTests extends LdapConnectorTestBase {
         Name name = new Name("o=Smallest," + SMALL_COMPANY_DN);
         attributes.add(name);
         attributes.add(AttributeBuilder.build("o", "Smallest"));
-        ObjectClass oclass = new ObjectClass("organization");
-        Uid uid = facade.create(oclass, attributes, null);
+        Uid uid = facade.create(LdapSchemaMapping.ANY_OBJECT_CLASS, attributes, null);
 
-        ConnectorObject newObject = facade.getObject(oclass, uid, null);
+        ConnectorObject newObject = facade.getObject(LdapSchemaMapping.ANY_OBJECT_CLASS, uid, null);
         assertEquals(name, newObject.getName());
     }
 
     @Test
-    public void createArbitraryWhenNameAttributesNotDefault() {
+    public void createDeviceWhenNameAttributesNotDefault() {
         LdapConfiguration config = newConfiguration();
         assertFalse(config.getUidAttribute().equalsIgnoreCase("entryDN"));
         config.setAnyObjectNameAttributes("cn");
         config.setBaseContexts(SMALL_COMPANY_DN);
+        config.setAnyObjectClasses("top", "device");
         ConnectorFacade facade = newFacade(config);
 
         doCreateDevice(facade);
     }
 
     @Test
-    public void createArbitraryWhenObjectClassesNotDefault() {
+    public void createDeviceWhenObjectClassesNotDefault() {
         LdapConfiguration config = newConfiguration();
         assertFalse(config.getUidAttribute().equalsIgnoreCase("entryDN"));
-        config.setAnyObjectClasses("top", "organization");
+        config.setAnyObjectClasses("top", "device");
         config.setBaseContexts(SMALL_COMPANY_DN);
         ConnectorFacade facade = newFacade(config);
 
@@ -226,10 +232,9 @@ public class LdapCreateTests extends LdapConnectorTestBase {
         attributes.add(AttributeBuilder.build("cn", DEVICE_0_CN));
         attributes.add(AttributeBuilder.build("serialNumber", DEVICE_0_SERIALNUMBER));
 
-        ObjectClass oclass = new ObjectClass("device");
-        Uid uid = facade.create(oclass, attributes, null);
+        Uid uid = facade.create(LdapSchemaMapping.ANY_OBJECT_CLASS, attributes, null);
 
-        ConnectorObject newObject = facade.getObject(oclass, uid, null);
+        ConnectorObject newObject = facade.getObject(LdapSchemaMapping.ANY_OBJECT_CLASS, uid, null);
         assertEquals(name, newObject.getName());
 
     }

--- a/src/test/java/net/tirasa/connid/bundles/ldap/search/LdapSearchTests.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/search/LdapSearchTests.java
@@ -416,7 +416,7 @@ public class LdapSearchTests extends LdapConnectorTestBase {
     @Test
     public void configurableAnyObjectScope() {
         LdapConfiguration configuration = newConfiguration();
-        configuration.setAnyObjectSearchScope("object");    
+        configuration.setAnyObjectSearchScope("object");
         configuration.setAnyObjectClasses("top", "organization");
         ConnectorFacade facade = newFacade(configuration);
 
@@ -435,7 +435,8 @@ public class LdapSearchTests extends LdapConnectorTestBase {
         facade = newFacade(configuration);
 
         // We can get the 'carrot laptop' device with an 'object' search by DN
-        ConnectorObject carrotLaptop = searchByAttribute(facade, LdapSchemaMapping.ANY_OBJECT_CLASS, new Name(CARROT_LAPTOP_DN));
+        ConnectorObject carrotLaptop = searchByAttribute(
+                facade, LdapSchemaMapping.ANY_OBJECT_CLASS, new Name(CARROT_LAPTOP_DN));
         assertNotNull(carrotLaptop);
 
         // Reconfigure for 'onelevel' search
@@ -554,7 +555,7 @@ public class LdapSearchTests extends LdapConnectorTestBase {
         // Find an organization to pass in OP_CONTAINER.
         ObjectClass oclass = new ObjectClass("organization");
         ConnectorObject organization = searchByAttribute(facade, oclass, new Name(ACME_DN));
-        
+
         OperationOptionsBuilder optionsBuilder = new OperationOptionsBuilder();
         optionsBuilder.setScope(OperationOptions.SCOPE_SUBTREE);
         optionsBuilder.setContainer(new QualifiedUid(oclass, organization.getUid()));


### PR DESCRIPTION
Following LDAP-37 and further configuration of a syncope instance, it was realised that when the “any object classes” capability was used for multiple object classes, the configuration values weren’t being utilised for all any objects.

It was then realised, that these would apply to the ALL special class, however, that then prevented search capabilities.

This fix is to make use of the ANY special class, instead of ALL, which can then be used in a resource mapping to pull the object classes from the resource configuration.