### PR TITLE
[LDAP-42] Pull the special name for any objects into a separate string

### DIFF
--- a/src/main/java/net/tirasa/connid/bundles/ldap/schema/LdapSchemaMapping.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/schema/LdapSchemaMapping.java
@@ -85,7 +85,9 @@ public class LdapSchemaMapping {
     // XXX should the naming attribute be present in the schema (e.g. "cn" for account)?
     // XXX need a method like getAttributesToReturn(String[] wanted);
     // XXX need to check that (extended) naming attributes really exist.
-    public static final ObjectClass ANY_OBJECT_CLASS = new ObjectClass(ObjectClassUtil.createSpecialName("ANY"));
+    public static final String ANY_OBJECT_NAME = ObjectClassUtil.createSpecialName("ANY");
+
+    public static final ObjectClass ANY_OBJECT_CLASS = new ObjectClass(ANY_OBJECT_NAME);
 
     /**
      * The LDAP attribute to map to {@link Name} by default.


### PR DESCRIPTION
Currently, the special name for ANY_OBJECTS is only defined within an argument.

It would be beneficial to have this pulled out into a seperate String variable, which can then be used.

For example, in the AD Sync strategies, oclass.is() is used with the special names of Accounts and Groups. In order to implement AD sync strategies with any objects, it would be cleaner in having this as a defined variable.