### PR TITLE
[LDAP-43] Any object identifier

### DIFF
--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
@@ -181,6 +181,11 @@ public class LdapConfiguration extends AbstractConfiguration {
     private String gidAttribute = "entryUUID";
 
     /**
+     * The LDAP attribute to map Aoid to
+     */
+    private String aoidAttribute = "entryUUID";
+
+    /**
      * Whether to read the schema from the server.
      */
     private boolean readSchema = true;
@@ -780,6 +785,17 @@ public class LdapConfiguration extends AbstractConfiguration {
     }
 
     @ConfigurationProperty(order = 30,
+            displayMessageKey = "aoidAttribute.display",
+            helpMessageKey = "aoidAttribute.help")
+    public String getAoidAttribute() {
+        return aoidAttribute;
+    }
+
+    public void setAoidAttribute(final String aoidAttribute) {
+        this.aoidAttribute = aoidAttribute;
+    }
+
+    @ConfigurationProperty(order = 31,
             displayMessageKey = "readSchema.display",
             helpMessageKey = "readSchema.help")
     public boolean isReadSchema() {
@@ -791,7 +807,7 @@ public class LdapConfiguration extends AbstractConfiguration {
     }
 
     // Sync properties getters and setters.
-    @ConfigurationProperty(order = 31, operations = { SyncOp.class },
+    @ConfigurationProperty(order = 32, operations = { SyncOp.class },
             displayMessageKey = "baseContextsToSynchronize.display",
             helpMessageKey = "baseContextsToSynchronize.help")
     public String[] getBaseContextsToSynchronize() {
@@ -802,7 +818,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         this.baseContextsToSynchronize = baseContextsToSynchronize.clone();
     }
 
-    @ConfigurationProperty(order = 32, operations = { SyncOp.class },
+    @ConfigurationProperty(order = 33, operations = { SyncOp.class },
             displayMessageKey = "objectClassesToSynchronize.display",
             helpMessageKey = "objectClassesToSynchronize.help")
     public String[] getObjectClassesToSynchronize() {
@@ -813,7 +829,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         this.objectClassesToSynchronize = objectClassesToSynchronize.clone();
     }
 
-    @ConfigurationProperty(order = 33, operations = { SyncOp.class },
+    @ConfigurationProperty(order = 34, operations = { SyncOp.class },
             displayMessageKey = "attributesToSynchronize.display",
             helpMessageKey = "attributesToSynchronize.help")
     public String[] getAttributesToSynchronize() {
@@ -824,7 +840,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         this.attributesToSynchronize = attributesToSynchronize.clone();
     }
 
-    @ConfigurationProperty(order = 34, operations = { SyncOp.class },
+    @ConfigurationProperty(order = 35, operations = { SyncOp.class },
             displayMessageKey = "modifiersNamesToFilterOut.display",
             helpMessageKey = "modifiersNamesToFilterOut.help")
     public String[] getModifiersNamesToFilterOut() {
@@ -835,7 +851,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         this.modifiersNamesToFilterOut = modifiersNamesToFilterOut.clone();
     }
 
-    @ConfigurationProperty(order = 35, operations = { SyncOp.class },
+    @ConfigurationProperty(order = 36, operations = { SyncOp.class },
             displayMessageKey = "accountSynchronizationFilter.display",
             helpMessageKey = "accountSynchronizationFilter.help")
     public String getAccountSynchronizationFilter() {
@@ -846,7 +862,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         this.accountSynchronizationFilter = accountSynchronizationFilter;
     }
 
-    @ConfigurationProperty(order = 36, operations = { SyncOp.class },
+    @ConfigurationProperty(order = 37, operations = { SyncOp.class },
             displayMessageKey = "changeLogBlockSize.display",
             helpMessageKey = "changeLogBlockSize.help")
     public int getChangeLogBlockSize() {
@@ -857,7 +873,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         this.changeLogBlockSize = changeLogBlockSize;
     }
 
-    @ConfigurationProperty(order = 37, operations = { SyncOp.class },
+    @ConfigurationProperty(order = 38, operations = { SyncOp.class },
             displayMessageKey = "changeNumberAttribute.display",
             helpMessageKey = "changeNumberAttribute.help")
     public String getChangeNumberAttribute() {
@@ -868,7 +884,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         this.changeNumberAttribute = changeNumberAttribute;
     }
 
-    @ConfigurationProperty(order = 38, operations = { SyncOp.class },
+    @ConfigurationProperty(order = 39, operations = { SyncOp.class },
             displayMessageKey = "filterWithOrInsteadOfAnd.display",
             helpMessageKey = "filterWithOrInsteadOfAnd.help")
     public boolean isFilterWithOrInsteadOfAnd() {
@@ -879,7 +895,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         this.filterWithOrInsteadOfAnd = filterWithOrInsteadOfAnd;
     }
 
-    @ConfigurationProperty(order = 39, operations = { SyncOp.class },
+    @ConfigurationProperty(order = 40, operations = { SyncOp.class },
             displayMessageKey = "removeLogEntryObjectClassFromFilter.display",
             helpMessageKey = "removeLogEntryObjectClassFromFilter.help")
     public boolean isRemoveLogEntryObjectClassFromFilter() {
@@ -890,7 +906,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         this.removeLogEntryObjectClassFromFilter = removeLogEntryObjectClassFromFilter;
     }
 
-    @ConfigurationProperty(order = 40, operations = { SyncOp.class },
+    @ConfigurationProperty(order = 41, operations = { SyncOp.class },
             displayMessageKey = "synchronizePasswords.display",
             helpMessageKey = "synchronizePasswords.help")
     public boolean isSynchronizePasswords() {
@@ -901,7 +917,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         this.synchronizePasswords = synchronizePasswords;
     }
 
-    @ConfigurationProperty(order = 41, operations = { SyncOp.class },
+    @ConfigurationProperty(order = 42, operations = { SyncOp.class },
             displayMessageKey = "passwordAttributeToSynchronize.display",
             helpMessageKey = "passwordAttributeToSynchronize.help")
     public String getPasswordAttributeToSynchronize() {
@@ -912,7 +928,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         this.passwordAttributeToSynchronize = passwordAttributeToSynchronize;
     }
 
-    @ConfigurationProperty(order = 42, operations = { SyncOp.class }, confidential = true,
+    @ConfigurationProperty(order = 43, operations = { SyncOp.class }, confidential = true,
             displayMessageKey = "passwordDecryptionKey.display",
             helpMessageKey = "passwordDecryptionKey.help")
     public GuardedByteArray getPasswordDecryptionKey() {
@@ -924,7 +940,7 @@ public class LdapConfiguration extends AbstractConfiguration {
                 copy() : null;
     }
 
-    @ConfigurationProperty(order = 43, operations = { SyncOp.class }, confidential = true,
+    @ConfigurationProperty(order = 44, operations = { SyncOp.class }, confidential = true,
             displayMessageKey = "passwordDecryptionInitializationVector.display",
             helpMessageKey = "passwordDecryptionInitializationVector.help")
     public GuardedByteArray getPasswordDecryptionInitializationVector() {
@@ -936,7 +952,7 @@ public class LdapConfiguration extends AbstractConfiguration {
                 ? passwordDecryptionInitializationVector.copy() : null;
     }
 
-    @ConfigurationProperty(order = 44,
+    @ConfigurationProperty(order = 45,
             displayMessageKey = "statusManagementClass.display",
             helpMessageKey = "statusManagementClass.help")
     public String getStatusManagementClass() {
@@ -947,7 +963,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         this.statusManagementClass = statusManagementClass;
     }
 
-    @ConfigurationProperty(order = 45,
+    @ConfigurationProperty(order = 46,
             displayMessageKey = "retrievePasswordsWithSearch.display",
             helpMessageKey = "retrievePasswordsWithSearch.help")
     public boolean getRetrievePasswordsWithSearch() {
@@ -958,7 +974,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         this.retrievePasswordsWithSearch = retrievePasswordsWithSearch;
     }
 
-    @ConfigurationProperty(order = 46,
+    @ConfigurationProperty(order = 47,
             displayMessageKey = "dnAttribute.display",
             helpMessageKey = "dnAttribute.help")
     public String getDnAttribute() {
@@ -969,7 +985,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         this.dnAttribute = dnAttribute;
     }
 
-    @ConfigurationProperty(order = 47,
+    @ConfigurationProperty(order = 48,
             displayMessageKey = "groupSearchFilter.display",
             helpMessageKey = "groupSearchFilter.help")
     public String getGroupSearchFilter() {
@@ -980,7 +996,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         this.groupSearchFilter = groupSearchFilter;
     }
 
-    @ConfigurationProperty(order = 48,
+    @ConfigurationProperty(order = 49,
             displayMessageKey = "readTimeout.display",
             helpMessageKey = "readTimeout.help")
     public long getReadTimeout() {
@@ -991,7 +1007,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         this.readTimeout = readTimeout;
     }
 
-    @ConfigurationProperty(order = 49,
+    @ConfigurationProperty(order = 50,
             displayMessageKey = "connectTimeout.display",
             helpMessageKey = "connectTimeout.help")
     public long getConnectTimeout() {
@@ -1002,7 +1018,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         this.connectTimeout = connectTimeout;
     }
 
-    @ConfigurationProperty(order = 50,
+    @ConfigurationProperty(order = 51,
             displayMessageKey = "syncStrategy.display",
             helpMessageKey = "syncStrategy.help")
     public String getSyncStrategy() {

--- a/src/main/java/net/tirasa/connid/bundles/ldap/schema/LdapSchemaMapping.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/schema/LdapSchemaMapping.java
@@ -210,23 +210,16 @@ public class LdapSchemaMapping {
      * @return the LDAP attribute which corresponds to {@link Uid}. Should never return null.
      */
     public String getLdapUidAttribute(final ObjectClass oclass) {
-        ObjectClass clazz;
         String idAttribute;
         if (oclass.equals(ObjectClass.GROUP)) {
-            clazz = oclass;
             idAttribute = conn.getConfiguration().getGidAttribute();
         } else if (oclass.equals(ObjectClass.ACCOUNT)) {
-            clazz = oclass;
             idAttribute = conn.getConfiguration().getUidAttribute();
         } else {
-            clazz = oclass.equals(ANY_OBJECT_CLASS) ? oclass : ObjectClass.ALL;
-            idAttribute = null;
+            idAttribute = conn.getConfiguration().getAoidAttribute();
         }
 
-        return StringUtil.isBlank(idAttribute)
-                ? conn.getConfiguration().getObjectClassMappingConfigs().get(clazz).
-                        getShortNameLdapAttributes().iterator().next()
-                : idAttribute;
+        return idAttribute;
     }
 
     /**

--- a/src/main/java/net/tirasa/connid/bundles/ldap/schema/LdapSchemaMapping.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/schema/LdapSchemaMapping.java
@@ -215,8 +215,11 @@ public class LdapSchemaMapping {
             idAttribute = conn.getConfiguration().getGidAttribute();
         } else if (oclass.equals(ObjectClass.ACCOUNT)) {
             idAttribute = conn.getConfiguration().getUidAttribute();
-        } else {
+        } else if (oclass.equals(LdapSchemaMapping.ANY_OBJECT_CLASS)) {
             idAttribute = conn.getConfiguration().getAoidAttribute();
+        } else {
+            idAttribute = conn.getConfiguration().getObjectClassMappingConfigs().get(ObjectClass.ALL).
+                        getShortNameLdapAttributes().iterator().next()
         }
 
         return idAttribute;

--- a/src/main/java/net/tirasa/connid/bundles/ldap/schema/LdapSchemaMapping.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/schema/LdapSchemaMapping.java
@@ -219,7 +219,7 @@ public class LdapSchemaMapping {
             idAttribute = conn.getConfiguration().getAoidAttribute();
         } else {
             idAttribute = conn.getConfiguration().getObjectClassMappingConfigs().get(ObjectClass.ALL).
-                        getShortNameLdapAttributes().iterator().next()
+                        getShortNameLdapAttributes().iterator().next();
         }
 
         return idAttribute;

--- a/src/test/java/net/tirasa/connid/bundles/ldap/LdapConfigurationTests.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/LdapConfigurationTests.java
@@ -332,6 +332,8 @@ public class LdapConfigurationTests {
         assertFalse(config.isUseVlvControls());
         assertEquals("uid", config.getVlvSortAttribute());
         assertEquals("entryUUID", config.getUidAttribute());
+        assertEquals("entryUUID", config.getGidAttribute());
+        assertEquals("entryUUID", config.getAoidAttribute());
         assertTrue(config.isReadSchema());
         assertEquals(0, config.getBaseContextsToSynchronize().length);
         assertTrue(Arrays.equals(new String[] { "inetOrgPerson" }, config.getObjectClassesToSynchronize()));

--- a/src/test/java/net/tirasa/connid/bundles/ldap/modify/LdapCreateTests.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/modify/LdapCreateTests.java
@@ -188,6 +188,7 @@ public class LdapCreateTests extends LdapConnectorTestBase {
         assertFalse(config.getUidAttribute().equalsIgnoreCase("entryDN"));
         config.setUidAttribute("entryDN");
         config.setGidAttribute("entryDN");
+        config.setAoidAttribute("entryDN");
         config.setAnyObjectNameAttributes("o");
         config.setBaseContexts(SMALL_COMPANY_DN);
         config.setAnyObjectClasses("top", "organization");

--- a/src/test/java/net/tirasa/connid/bundles/ldap/modify/LdapUpdateTests.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/modify/LdapUpdateTests.java
@@ -188,6 +188,7 @@ public class LdapUpdateTests extends LdapConnectorTestBase {
         assertFalse(config.getUidAttribute().equalsIgnoreCase("entryDN"));
         config.setUidAttribute("entryDN");
         config.setGidAttribute("entryDN");
+        config.setAoidAttribute("entryDN");
         ConnectorFacade facade = newFacade(config);
         ConnectorObject bugs = searchByAttribute(facade, ObjectClass.ACCOUNT, new Name(BUGS_BUNNY_DN));
 

--- a/src/test/java/net/tirasa/connid/bundles/ldap/search/LdapSearchTests.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/search/LdapSearchTests.java
@@ -613,6 +613,7 @@ public class LdapSearchTests extends LdapConnectorTestBase {
         assertFalse(config.getUidAttribute().equalsIgnoreCase("cn"));
         config.setUidAttribute("cn");
         config.setGidAttribute("cn");
+        config.setAoidAttribute("cn");
         ConnectorFacade facade = newFacade(config);
 
         ConnectorObject bunny = searchByAttribute(facade, ObjectClass.ACCOUNT, new Uid(BUGS_BUNNY_CN));
@@ -625,6 +626,7 @@ public class LdapSearchTests extends LdapConnectorTestBase {
         assertFalse(config.getUidAttribute().equalsIgnoreCase("entryDN"));
         config.setUidAttribute("entryDN");
         config.setGidAttribute("entryDN");
+        config.setAoidAttribute("entryDN");
         ConnectorFacade facade = newFacade(config);
 
         ConnectorObject bunny = searchByAttribute(facade, ObjectClass.ACCOUNT, new Uid(BUGS_BUNNY_DN));


### PR DESCRIPTION
Currently only user and groups have a configurable ‘id’ attribute.

Adding an aoid attribute for any objects, makes it clearer as to what is the id attribute for any objects, and helps in implementing any-object functionality for the AD bundle