### PR TITLE
[LDAP-44] Cater for extendability and inheritance

### DIFF
--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapAuthenticate.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapAuthenticate.java
@@ -118,7 +118,7 @@ public class LdapAuthenticate {
         if (result != null && result.length > 0) {
             return Arrays.asList(result);
         }
-        return conn.getSchemaMapping().getUserNameLdapAttributes(oclass);
+        return conn.getSchema().getUserNameLdapAttributes(oclass);
     }
 
     protected static boolean isSuccess(AuthenticationResult authResult) {

--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapAuthenticate.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapAuthenticate.java
@@ -45,13 +45,13 @@ import net.tirasa.connid.bundles.ldap.search.LdapSearches;
 
 public class LdapAuthenticate {
 
-    private final LdapConnection conn;
+    protected final LdapConnection conn;
 
-    private final ObjectClass oclass;
+    protected final ObjectClass oclass;
 
-    private final String username;
+    protected final String username;
 
-    private final OperationOptions options;
+    protected final OperationOptions options;
 
     public LdapAuthenticate(LdapConnection conn, ObjectClass oclass, String username, OperationOptions options) {
         this.conn = conn;
@@ -90,7 +90,7 @@ public class LdapAuthenticate {
         return authnObject.getUid();
     }
 
-    private ConnectorObject getObjectToAuthenticate() {
+    protected ConnectorObject getObjectToAuthenticate() {
         List<String> userNameAttrs = getUserNameAttributes();
         Map<String, ConnectorObject> entryDN2Object = new HashMap<String, ConnectorObject>();
         final String dnAttributeName = conn.getConfiguration().getDnAttribute();
@@ -113,7 +113,7 @@ public class LdapAuthenticate {
         return null;
     }
 
-    private List<String> getUserNameAttributes() {
+    protected List<String> getUserNameAttributes() {
         String[] result = LdapConstants.getLdapUidAttributes(options);
         if (result != null && result.length > 0) {
             return Arrays.asList(result);
@@ -121,7 +121,7 @@ public class LdapAuthenticate {
         return conn.getSchemaMapping().getUserNameLdapAttributes(oclass);
     }
 
-    private static boolean isSuccess(AuthenticationResult authResult) {
+    protected static boolean isSuccess(AuthenticationResult authResult) {
         // We consider PASSWORD_EXPIRED to be a success, because it means the credentials were right.
         return authResult.getType() != null 
                 && (authResult.getType().equals(AuthenticationResultType.SUCCESS) 

--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
@@ -365,13 +365,13 @@ public class LdapConfiguration extends AbstractConfiguration {
         checkLdapSyncStrategy();
     }
 
-    private void checkNotBlank(String value, String errorMessage) {
+    protected void checkNotBlank(String value, String errorMessage) {
         if (StringUtil.isBlank(value)) {
             failValidation(errorMessage);
         }
     }
 
-    private void checkNotBlank(GuardedByteArray array, String errorMessage) {
+    protected void checkNotBlank(GuardedByteArray array, String errorMessage) {
         final int[] length = { 0 };
         if (array != null) {
             array.access(new Accessor() {
@@ -388,7 +388,7 @@ public class LdapConfiguration extends AbstractConfiguration {
     }
 
     @SuppressWarnings("unchecked")
-    private void checkLdapSyncStrategy() {
+    protected void checkLdapSyncStrategy() {
         try {
             Class<?> clazz = Class.forName(syncStrategy);
             if (LdapSyncStrategy.class.isAssignableFrom(clazz) && !Modifier.isAbstract(clazz.getModifiers())) {
@@ -401,19 +401,19 @@ public class LdapConfiguration extends AbstractConfiguration {
         }
     }
 
-    private void checkNotEmpty(Collection<?> collection, String errorMessage) {
+    protected void checkNotEmpty(Collection<?> collection, String errorMessage) {
         if (collection.isEmpty()) {
             failValidation(errorMessage);
         }
     }
 
-    private void checkNotEmpty(String[] array, String errorMessage) {
+    protected void checkNotEmpty(String[] array, String errorMessage) {
         if (array == null || array.length < 1) {
             failValidation(errorMessage);
         }
     }
 
-    private void checkNoBlankValues(Collection<String> collection, String errorMessage) {
+    protected void checkNoBlankValues(Collection<String> collection, String errorMessage) {
         for (String each : collection) {
             if (StringUtil.isBlank(each)) {
                 failValidation(errorMessage);
@@ -421,7 +421,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         }
     }
 
-    private void checkNoBlankValues(String[] array, String errorMessage) {
+    protected void checkNoBlankValues(String[] array, String errorMessage) {
         for (String each : array) {
             if (StringUtil.isBlank(each)) {
                 failValidation(errorMessage);
@@ -429,7 +429,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         }
     }
 
-    private void checkNoInvalidLdapNames(String[] array, String errorMessage) {
+    protected void checkNoInvalidLdapNames(String[] array, String errorMessage) {
         for (String each : array) {
             try {
                 new LdapName(each);
@@ -439,7 +439,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         }
     }
 
-    private void checkValidScope(String scope, String errorMessage) {
+    protected void checkValidScope(String scope, String errorMessage) {
         switch (scope) {
             case OperationOptions.SCOPE_OBJECT:
             case OperationOptions.SCOPE_ONE_LEVEL:
@@ -450,7 +450,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         }
     }
 
-    private void failValidation(String key, Object... args) {
+    protected void failValidation(String key, Object... args) {
         String message = getConnectorMessages().format(key, null, args);
         throw new ConfigurationException(message);
     }
@@ -1090,7 +1090,7 @@ public class LdapConfiguration extends AbstractConfiguration {
         return result;
     }
 
-    private EqualsHashCodeBuilder createHashCodeBuilder() {
+    protected EqualsHashCodeBuilder createHashCodeBuilder() {
         EqualsHashCodeBuilder builder = new EqualsHashCodeBuilder();
         // Exposed configuration properties.
         builder.append(host);

--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
@@ -225,6 +225,10 @@ public class LdapConfiguration extends AbstractConfiguration {
 
     private Class<? extends LdapSyncStrategy> syncStrategyClass = null;
 
+    private Class<? extends LdapSyncStrategy> fallbackSyncStrategyClass = SunDSChangeLogSyncStrategy.class;
+
+    private Class<? extends LdapConnection> connectionClass = LdapConnection.class;
+
     /**
      * The SearchScope for user objects
      */
@@ -1031,6 +1035,22 @@ public class LdapConfiguration extends AbstractConfiguration {
 
     public Class<? extends LdapSyncStrategy> getSyncStrategyClass() {
         return syncStrategyClass;
+    }
+
+    protected Class<? extends LdapSyncStrategy> getFallbackSyncStrategyClass() {
+        return fallbackSyncStrategyClass;
+    }
+
+    protected void setFallbackSyncStrategyClass(Class<? extends LdapSyncStrategy> fallbackSyncStrategyClass) {
+        this.fallbackSyncStrategyClass = fallbackSyncStrategyClass;
+    }
+
+    protected Class<? extends LdapConnection> getConnectionClass() {
+        return connectionClass;
+    }
+
+    protected void setConnectionClass(Class<? extends LdapConnection> connectionClass) {
+        this.connectionClass = connectionClass;
     }
 
     // Getters and setters for configuration properties end here.

--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapConfiguration.java
@@ -37,7 +37,7 @@ import javax.naming.ldap.LdapName;
 import net.tirasa.connid.bundles.ldap.commons.LdapConstants;
 import net.tirasa.connid.bundles.ldap.commons.LdapUtil;
 import net.tirasa.connid.bundles.ldap.commons.ObjectClassMappingConfig;
-import net.tirasa.connid.bundles.ldap.schema.LdapSchemaMapping;
+import net.tirasa.connid.bundles.ldap.schema.LdapSchema;
 import net.tirasa.connid.bundles.ldap.search.DefaultSearchStrategy;
 import net.tirasa.connid.bundles.ldap.sync.LdapSyncStrategy;
 import net.tirasa.connid.bundles.ldap.sync.sunds.SunDSChangeLogSyncStrategy;
@@ -258,7 +258,7 @@ public class LdapConfiguration extends AbstractConfiguration {
             false, CollectionUtil.newList("cn"));
 
     private final ObjectClassMappingConfig anyObjectConfig = new ObjectClassMappingConfig(
-            LdapSchemaMapping.ANY_OBJECT_CLASS,
+            LdapSchema.ANY_OBJECT_CLASS,
             CollectionUtil.newList("top"),
             false, CollectionUtil.newList(DEFAULT_ID_ATTRIBUTE));
 

--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapConnection.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapConnection.java
@@ -41,7 +41,7 @@ import net.tirasa.connid.bundles.ldap.commons.LdapNativeSchema;
 import net.tirasa.connid.bundles.ldap.commons.LdapUtil;
 import net.tirasa.connid.bundles.ldap.commons.ServerNativeSchema;
 import net.tirasa.connid.bundles.ldap.commons.StaticNativeSchema;
-import net.tirasa.connid.bundles.ldap.schema.LdapSchemaMapping;
+import net.tirasa.connid.bundles.ldap.schema.LdapSchema;
 import org.identityconnectors.common.CollectionUtil;
 import org.identityconnectors.common.Pair;
 import org.identityconnectors.common.StringUtil;
@@ -101,7 +101,7 @@ public class LdapConnection {
 
     protected final LdapConfiguration config;
 
-    protected final LdapSchemaMapping schemaMapping;
+    protected final LdapSchema schema;
 
     protected LdapContext initCtx;
 
@@ -111,7 +111,7 @@ public class LdapConnection {
 
     public LdapConnection(LdapConfiguration config) {
         this.config = config;
-        schemaMapping = new LdapSchemaMapping(this);
+        schema = new LdapSchema(this);
     }
 
     public String format(String key, String dflt, Object... args) {
@@ -256,8 +256,8 @@ public class LdapConnection {
         }
     }
 
-    public LdapSchemaMapping getSchemaMapping() {
-        return schemaMapping;
+    public LdapSchema getSchema() {
+        return schema;
     }
 
     public LdapNativeSchema createNativeSchema() {

--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapConnection.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapConnection.java
@@ -95,19 +95,19 @@ public class LdapConnection {
         LDAP_BINARY_OPTION_ATTRS.add("supportedAlgorithms");
     }
 
-    private static final String LDAP_CTX_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
+    protected static final String LDAP_CTX_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
 
     private static final Log LOG = Log.getLog(LdapConnection.class);
 
-    private final LdapConfiguration config;
+    protected final LdapConfiguration config;
 
-    private final LdapSchemaMapping schemaMapping;
+    protected final LdapSchemaMapping schemaMapping;
 
-    private LdapContext initCtx;
+    protected LdapContext initCtx;
 
-    private Set<String> supportedControls;
+    protected Set<String> supportedControls;
 
-    private ServerType serverType;
+    protected ServerType serverType;
 
     public LdapConnection(LdapConfiguration config) {
         this.config = config;
@@ -130,7 +130,7 @@ public class LdapConnection {
         return initCtx;
     }
 
-    private LdapContext connect(String principal, GuardedString credentials) {
+    protected LdapContext connect(String principal, GuardedString credentials) {
         Pair<AuthenticationResult, LdapContext> pair = createContext(principal, credentials);
         if (pair.first.getType().equals(AuthenticationResultType.SUCCESS)) {
             return pair.second;
@@ -139,7 +139,7 @@ public class LdapConnection {
         throw new IllegalStateException("Should never get here");
     }
 
-    private Pair<AuthenticationResult, LdapContext> createContext(String principal, GuardedString credentials) {
+    protected Pair<AuthenticationResult, LdapContext> createContext(String principal, GuardedString credentials) {
         final List<Pair<AuthenticationResult, LdapContext>> result =
                 new ArrayList<Pair<AuthenticationResult, LdapContext>>(1);
 
@@ -183,7 +183,7 @@ public class LdapConnection {
         return result.get(0);
     }
 
-    private Pair<AuthenticationResult, LdapContext> createContext(final Hashtable<?, ?> env) {
+    protected Pair<AuthenticationResult, LdapContext> createContext(final Hashtable<?, ?> env) {
         AuthenticationResult authnResult = null;
         InitialLdapContext context = null;
         try {
@@ -214,7 +214,7 @@ public class LdapConnection {
         return new Pair<AuthenticationResult, LdapContext>(authnResult, context);
     }
 
-    private static boolean hasPasswordExpiredControl(Control[] controls) {
+    protected static boolean hasPasswordExpiredControl(Control[] controls) {
         if (controls != null) {
             for (Control control : controls) {
                 if (control instanceof PasswordExpiredResponseControl) {
@@ -225,7 +225,7 @@ public class LdapConnection {
         return false;
     }
 
-    private String getLdapUrls() {
+    protected String getLdapUrls() {
         StringBuilder builder = new StringBuilder();
         builder.append("ldap://");
         builder.append(config.getHost());
@@ -246,7 +246,7 @@ public class LdapConnection {
         }
     }
 
-    private static void quietClose(LdapContext ctx) {
+    protected static void quietClose(LdapContext ctx) {
         try {
             if (ctx != null) {
                 ctx.close();
@@ -303,7 +303,7 @@ public class LdapConnection {
         return getSupportedControls().contains(oid);
     }
 
-    private Set<String> getSupportedControls() {
+    protected Set<String> getSupportedControls() {
         if (supportedControls == null) {
             try {
                 Attributes attrs = getInitialContext().getAttributes("", new String[] { "supportedControl" });
@@ -324,7 +324,7 @@ public class LdapConnection {
         return serverType;
     }
 
-    private ServerType detectServerType() {
+    protected ServerType detectServerType() {
         try {
             Attributes attrs = getInitialContext().getAttributes("", new String[] { "vendorVersion" });
             String vendorVersion = LdapUtil.getStringAttrValue(attrs, "vendorVersion");
@@ -379,9 +379,9 @@ public class LdapConnection {
 
     public static class AuthenticationResult {
 
-        private final AuthenticationResultType type;
+        protected final AuthenticationResultType type;
 
-        private final Exception cause;
+        protected final Exception cause;
 
         public AuthenticationResult(AuthenticationResultType type) {
             this(type, null);

--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapConnection.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapConnection.java
@@ -101,7 +101,7 @@ public class LdapConnection {
 
     protected final LdapConfiguration config;
 
-    protected final LdapSchema schema;
+    protected LdapSchema schema;
 
     protected LdapContext initCtx;
 

--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapConnector.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapConnector.java
@@ -70,14 +70,14 @@ public class LdapConnector implements
     /**
      * The configuration for this connector instance.
      */
-    private LdapConfiguration config;
+    protected LdapConfiguration config;
 
     /**
      * The connection to the LDAP server.
      */
-    private LdapConnection conn;
+    protected LdapConnection conn;
 
-    private LdapSyncStrategy syncStrategy;
+    protected LdapSyncStrategy syncStrategy;
 
     @Override
     public Configuration getConfiguration() {

--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapConnector.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapConnector.java
@@ -116,7 +116,7 @@ public class LdapConnector implements
 
     @Override
     public Schema schema() {
-        return conn.getSchemaMapping().schema();
+        return conn.getSchema().schema();
     }
 
     @Override
@@ -142,7 +142,7 @@ public class LdapConnector implements
     public FilterTranslator<LdapFilter> createFilterTranslator(
             final ObjectClass oclass,
             final OperationOptions options) {
-        return new LdapFilterTranslator(conn.getSchemaMapping(), oclass);
+        return new LdapFilterTranslator(conn.getSchema(), oclass);
     }
 
     @Override

--- a/src/main/java/net/tirasa/connid/bundles/ldap/commons/LdapNativeSchema.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/commons/LdapNativeSchema.java
@@ -23,7 +23,6 @@
  */
 package net.tirasa.connid.bundles.ldap.commons;
 
-import net.tirasa.connid.bundles.ldap.commons.LdapAttributeType;
 import java.util.Set;
 
 /**

--- a/src/main/java/net/tirasa/connid/bundles/ldap/modify/LdapCreate.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/modify/LdapCreate.java
@@ -49,9 +49,9 @@ import org.identityconnectors.framework.common.objects.Uid;
 public class LdapCreate extends LdapModifyOperation {
 
     // TODO old LDAP connector has a note about a RFC 4527 Post-Read control.
-    private final ObjectClass oclass;
+    protected final ObjectClass oclass;
 
-    private final Set<Attribute> attrs;
+    protected final Set<Attribute> attrs;
 
     public LdapCreate(
             final LdapConnection conn,
@@ -72,7 +72,7 @@ public class LdapCreate extends LdapModifyOperation {
         }
     }
 
-    private Uid executeImpl() throws NamingException {
+    protected Uid executeImpl() throws NamingException {
         Name nameAttr = AttributeUtil.getNameFromAttributes(attrs);
         if (nameAttr == null) {
             throw new IllegalArgumentException("No Name attribute provided in the attributes");

--- a/src/main/java/net/tirasa/connid/bundles/ldap/modify/LdapCreate.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/modify/LdapCreate.java
@@ -96,14 +96,14 @@ public class LdapCreate extends LdapModifyOperation {
                 posixGroups.addAll(
                         LdapUtil.checkedListByFilter(CollectionUtil.nullAsEmpty(attr.getValue()), String.class));
             } else if (attr.is(OperationalAttributes.PASSWORD_NAME)) {
-                pwdAttr = conn.getSchemaMapping().encodePassword(attr);
+                pwdAttr = conn.getSchema().encodePassword(attr);
             } else if (attr.is(OperationalAttributes.ENABLE_NAME)) {
                 // manage enable/disable status
                 if (attr.getValue() != null && !attr.getValue().isEmpty()) {
                     status = Boolean.valueOf(attr.getValue().get(0).toString());
                 }
             } else {
-                ldapAttr = conn.getSchemaMapping().encodeAttribute(oclass, attr);
+                ldapAttr = conn.getSchema().encodeAttribute(oclass, attr);
                 // Do not send empty attributes. 
                 // The server complains for "uniqueMember", for example.
                 if (ldapAttr != null && ldapAttr.size() > 0) {
@@ -129,11 +129,11 @@ public class LdapCreate extends LdapModifyOperation {
                 public void access(javax.naming.directory.Attribute passwordAttr) {
                     hashPassword(passwordAttr, null);
                     ldapAttrs.put(passwordAttr);
-                    entryDN[0] = conn.getSchemaMapping().create(oclass, nameAttr, ldapAttrs);
+                    entryDN[0] = conn.getSchema().create(oclass, nameAttr, ldapAttrs);
                 }
             });
         } else {
-            entryDN[0] = conn.getSchemaMapping().create(oclass, nameAttr, ldapAttrs);
+            entryDN[0] = conn.getSchema().create(oclass, nameAttr, ldapAttrs);
         }
 
         if (!CollectionUtil.isEmpty(ldapGroups)) {
@@ -146,6 +146,6 @@ public class LdapCreate extends LdapModifyOperation {
             groupHelper.addPosixGroupMemberships(posixRefAttr, posixGroups);
         }
 
-        return conn.getSchemaMapping().createUid(oclass, entryDN[0]);
+        return conn.getSchema().createUid(oclass, entryDN[0]);
     }
 }

--- a/src/main/java/net/tirasa/connid/bundles/ldap/modify/LdapDelete.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/modify/LdapDelete.java
@@ -36,9 +36,9 @@ import net.tirasa.connid.bundles.ldap.search.LdapSearches;
 
 public class LdapDelete extends LdapModifyOperation {
 
-    private final ObjectClass oclass;
+    protected final ObjectClass oclass;
 
-    private final Uid uid;
+    protected final Uid uid;
 
     public LdapDelete(LdapConnection conn, ObjectClass oclass, Uid uid) {
         super(conn);

--- a/src/main/java/net/tirasa/connid/bundles/ldap/modify/LdapUpdate.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/modify/LdapUpdate.java
@@ -61,9 +61,9 @@ public class LdapUpdate extends LdapModifyOperation {
 
     private static final Log LOG = Log.getLog(LdapUpdate.class);
 
-    private final ObjectClass oclass;
+    protected final ObjectClass oclass;
 
-    private final Uid uid;
+    protected final Uid uid;
 
     public LdapUpdate(final LdapConnection conn, final ObjectClass oclass, final Uid uid) {
         super(conn);
@@ -358,7 +358,7 @@ public class LdapUpdate extends LdapModifyOperation {
         return uid;
     }
 
-    private void checkRemovedPosixRefAttrs(
+    protected void checkRemovedPosixRefAttrs(
             final Set<String> removedPosixRefAttrs,
             final Set<GroupMembership> memberships) {
 
@@ -370,7 +370,7 @@ public class LdapUpdate extends LdapModifyOperation {
         }
     }
 
-    private Pair<Attributes, GuardedPasswordAttribute> getAttributesToModify(final Set<Attribute> attrs) {
+    protected Pair<Attributes, GuardedPasswordAttribute> getAttributesToModify(final Set<Attribute> attrs) {
         BasicAttributes ldapAttrs = new BasicAttributes();
         GuardedPasswordAttribute pwdAttr = null;
         for (Attribute attr : attrs) {
@@ -408,7 +408,7 @@ public class LdapUpdate extends LdapModifyOperation {
         return Pair.of(ldapAttrs, pwdAttr);
     }
 
-    private void modifyAttributes(
+    protected void modifyAttributes(
             final String entryDN,
             final Pair<Attributes, GuardedPasswordAttribute> attrs,
             final int ldapModifyOp) {
@@ -432,7 +432,7 @@ public class LdapUpdate extends LdapModifyOperation {
         }
     }
 
-    private void modifyAttributes(final String entryDN, final List<ModificationItem> modItems) {
+    protected void modifyAttributes(final String entryDN, final List<ModificationItem> modItems) {
         LOG.ok("About to apply to {0} the following modifications: {1}", entryDN, modItems);
 
         try {
@@ -442,7 +442,7 @@ public class LdapUpdate extends LdapModifyOperation {
         }
     }
 
-    private static List<String> getStringListValue(final Set<Attribute> attrs, final String attrName) {
+    public static List<String> getStringListValue(final Set<Attribute> attrs, final String attrName) {
         return Optional.ofNullable(AttributeUtil.find(attrName, attrs)).
                 map(attr -> LdapUtil.checkedListByFilter(CollectionUtil.nullAsEmpty(attr.getValue()), String.class)).
                 orElse(null);

--- a/src/main/java/net/tirasa/connid/bundles/ldap/modify/LdapUpdate.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/modify/LdapUpdate.java
@@ -89,7 +89,7 @@ public class LdapUpdate extends LdapModifyOperation {
             updateAttrs = CollectionUtil.newSet(attrs);
             updateAttrs.remove(newName);
             updateAttrs.remove(AttributeUtil.find(LdapUtil.getDNAttributeName(newName), attrs));
-            newEntryDN = conn.getSchemaMapping().getEntryDN(oclass, newName);
+            newEntryDN = conn.getSchema().getEntryDN(oclass, newName);
         }
 
         List<String> ldapGroups = getStringListValue(updateAttrs, LdapConstants.LDAP_GROUPS_NAME);
@@ -132,7 +132,7 @@ public class LdapUpdate extends LdapModifyOperation {
                 posixMember.getPosixRefAttributes();
             }
             oldEntryDN = entryDN;
-            entryDN = conn.getSchemaMapping().rename(oclass, oldEntryDN, newName);
+            entryDN = conn.getSchema().rename(oclass, oldEntryDN, newName);
         }
 
         // Update the LDAP groups.
@@ -185,7 +185,7 @@ public class LdapUpdate extends LdapModifyOperation {
 
         groupHelper.modifyPosixGroupMemberships(posixGroupMod);
 
-        return conn.getSchemaMapping().createUid(oclass, entryDN);
+        return conn.getSchema().createUid(oclass, entryDN);
     }
 
     public Set<AttributeDelta> updateDelta(final Set<AttributeDelta> modifications) {
@@ -213,9 +213,9 @@ public class LdapUpdate extends LdapModifyOperation {
             } else if (LdapConstants.isPosixGroups(attrDelta.getName())) {
                 // Handled elsewhere.
             } else if (attrDelta.is(OperationalAttributes.PASSWORD_NAME)) {
-                guardedPasswordAttribute = conn.getSchemaMapping().encodePassword(attrDelta);
+                guardedPasswordAttribute = conn.getSchema().encodePassword(attrDelta);
             } else {
-                modItems.addAll(conn.getSchemaMapping().encodeAttribute(oclass, attrDelta));
+                modItems.addAll(conn.getSchema().encodeAttribute(oclass, attrDelta));
             }
         }
 
@@ -385,9 +385,9 @@ public class LdapUpdate extends LdapModifyOperation {
             } else if (LdapConstants.isPosixGroups(attr.getName())) {
                 // Handled elsewhere.
             } else if (attr.is(OperationalAttributes.PASSWORD_NAME)) {
-                pwdAttr = conn.getSchemaMapping().encodePassword(attr);
+                pwdAttr = conn.getSchema().encodePassword(attr);
             } else {
-                ldapAttr = conn.getSchemaMapping().encodeAttribute(oclass, attr);
+                ldapAttr = conn.getSchema().encodeAttribute(oclass, attr);
             }
             if (ldapAttr != null) {
                 javax.naming.directory.Attribute existingAttr = ldapAttrs.get(ldapAttr.getID());

--- a/src/main/java/net/tirasa/connid/bundles/ldap/schema/GuardedPasswordAttribute.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/schema/GuardedPasswordAttribute.java
@@ -48,13 +48,13 @@ public abstract class GuardedPasswordAttribute {
         void access(Attribute passwordAttribute);
     }
 
-    private static final class Simple extends GuardedPasswordAttribute {
+    public static class Simple extends GuardedPasswordAttribute {
 
-        private final String attrName;
+        protected final String attrName;
 
-        private final GuardedString password;
+        protected final GuardedString password;
 
-        private Simple(final String attrName, final GuardedString password) {
+        protected Simple(final String attrName, final GuardedString password) {
             super();
 
             this.attrName = attrName;
@@ -92,11 +92,11 @@ public abstract class GuardedPasswordAttribute {
         }
     }
 
-    private static final class Empty extends GuardedPasswordAttribute {
+    public static class Empty extends GuardedPasswordAttribute {
 
-        private final String attrName;
+        protected final String attrName;
 
-        private Empty(final String attrName) {
+        protected Empty(final String attrName) {
             super();
 
             this.attrName = attrName;

--- a/src/main/java/net/tirasa/connid/bundles/ldap/schema/LdapSchema.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/schema/LdapSchema.java
@@ -71,9 +71,9 @@ import org.identityconnectors.framework.common.objects.Uid;
  *
  * @author Andrei Badea
  */
-public class LdapSchemaMapping {
+public class LdapSchema {
 
-    private static final Log LOG = Log.getLog(LdapSchemaMapping.class);
+    private static final Log LOG = Log.getLog(LdapSchema.class);
 
     // XXX
     // - which attrs returned by default? Currently only userApplications.
@@ -99,7 +99,7 @@ public class LdapSchemaMapping {
 
     protected Schema schema;
 
-    public LdapSchemaMapping(LdapConnection conn) {
+    public LdapSchema(LdapConnection conn) {
         this.conn = conn;
     }
 
@@ -214,7 +214,7 @@ public class LdapSchemaMapping {
             idAttribute = conn.getConfiguration().getGidAttribute();
         } else if (oclass.equals(ObjectClass.ACCOUNT)) {
             idAttribute = conn.getConfiguration().getUidAttribute();
-        } else if (oclass.equals(LdapSchemaMapping.ANY_OBJECT_CLASS)) {
+        } else if (oclass.equals(LdapSchema.ANY_OBJECT_CLASS)) {
             idAttribute = conn.getConfiguration().getAoidAttribute();
         } else {
             idAttribute = conn.getConfiguration().getObjectClassMappingConfigs().get(ObjectClass.ALL).
@@ -330,7 +330,7 @@ public class LdapSchemaMapping {
             ldapAttrs.put(initialAttrEnum.nextElement());
         }
         BasicAttribute objectClass = new BasicAttribute("objectClass");
-        for (String ldapClass : conn.getSchemaMapping().getEffectiveLdapClasses(
+        for (String ldapClass : conn.getSchema().getEffectiveLdapClasses(
                 oclass)) {
             objectClass.add(ldapClass);
         }

--- a/src/main/java/net/tirasa/connid/bundles/ldap/schema/LdapSchemaBuilder.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/schema/LdapSchemaBuilder.java
@@ -44,15 +44,15 @@ import net.tirasa.connid.bundles.ldap.commons.LdapNativeSchema;
 import net.tirasa.connid.bundles.ldap.commons.ObjectClassMappingConfig;
 import net.tirasa.connid.bundles.ldap.LdapConnection.ServerType;
 
-class LdapSchemaBuilder {
+public class LdapSchemaBuilder {
 
     private static final Log LOG = Log.getLog(LdapSchemaBuilder.class);
 
-    private final LdapConnection conn;
+    protected final LdapConnection conn;
 
-    private final LdapNativeSchema nativeSchema;
+    protected final LdapNativeSchema nativeSchema;
 
-    private Schema schema;
+    protected Schema schema;
 
     public LdapSchemaBuilder(LdapConnection conn) {
         this.conn = conn;
@@ -66,7 +66,7 @@ class LdapSchemaBuilder {
         return schema;
     }
 
-    private void buildSchema() {
+    protected void buildSchema() {
         SchemaBuilder schemaBld = new SchemaBuilder(LdapConnector.class);
 
         for (ObjectClassMappingConfig oclassConfig : conn.getConfiguration().getObjectClassMappingConfigs().values()) {
@@ -112,7 +112,7 @@ class LdapSchemaBuilder {
         schema = schemaBld.build();
     }
 
-    private Set<AttributeInfo> createAttributeInfos(Collection<String> ldapClasses) {
+    protected Set<AttributeInfo> createAttributeInfos(Collection<String> ldapClasses) {
         Set<AttributeInfo> result = new HashSet<AttributeInfo>();
 
         Set<String> requiredAttrs = getRequiredAttributes(ldapClasses);
@@ -126,7 +126,7 @@ class LdapSchemaBuilder {
         return result;
     }
 
-    private Set<String> getRequiredAttributes(Collection<String> ldapClasses) {
+    protected Set<String> getRequiredAttributes(Collection<String> ldapClasses) {
         Set<String> result = new HashSet<String>();
         for (String ldapClass : ldapClasses) {
             result.addAll(nativeSchema.getRequiredAttributes(ldapClass));
@@ -134,7 +134,7 @@ class LdapSchemaBuilder {
         return result;
     }
 
-    private Set<String> getOptionalAttributes(Collection<String> ldapClasses) {
+    protected Set<String> getOptionalAttributes(Collection<String> ldapClasses) {
         Set<String> result = new HashSet<String>();
         for (String ldapClass : ldapClasses) {
             result.addAll(nativeSchema.getOptionalAttributes(ldapClass));
@@ -142,7 +142,7 @@ class LdapSchemaBuilder {
         return result;
     }
 
-    private void addAttributeInfos(
+    protected void addAttributeInfos(
             Collection<String> ldapClasses,
             Set<String> attrs,
             Set<Flags> add,
@@ -154,7 +154,7 @@ class LdapSchemaBuilder {
         }
     }
 
-    private void addAttributeInfo(
+    protected void addAttributeInfo(
             Collection<String> ldapClasses,
             String ldapAttrName,
             String realName,

--- a/src/main/java/net/tirasa/connid/bundles/ldap/schema/LdapSchemaMapping.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/schema/LdapSchemaMapping.java
@@ -49,7 +49,6 @@ import net.tirasa.connid.bundles.ldap.LdapConnection;
 import net.tirasa.connid.bundles.ldap.commons.LdapEntry;
 import net.tirasa.connid.bundles.ldap.commons.ObjectClassMappingConfig;
 import org.identityconnectors.common.CollectionUtil;
-import org.identityconnectors.common.StringUtil;
 import org.identityconnectors.common.logging.Log;
 import org.identityconnectors.common.security.GuardedString;
 import org.identityconnectors.framework.common.exceptions.ConnectorException;
@@ -92,13 +91,13 @@ public class LdapSchemaMapping {
     /**
      * The LDAP attribute to map to {@link Name} by default.
      */
-    static final String DEFAULT_LDAP_NAME_ATTR = "entryDN";
+    protected static final String DEFAULT_LDAP_NAME_ATTR = "entryDN";
 
-    private final LdapConnection conn;
+    protected final LdapConnection conn;
 
-    private final Map<String, Set<String>> ldapClass2Effective = newCaseInsensitiveMap();
+    protected final Map<String, Set<String>> ldapClass2Effective = newCaseInsensitiveMap();
 
-    private Schema schema;
+    protected Schema schema;
 
     public LdapSchemaMapping(LdapConnection conn) {
         this.conn = conn;
@@ -111,7 +110,7 @@ public class LdapSchemaMapping {
         return schema;
     }
 
-    private Set<String> getEffectiveLdapClasses(String ldapClass) {
+    protected Set<String> getEffectiveLdapClasses(String ldapClass) {
         Set<String> result = ldapClass2Effective.get(ldapClass);
         if (result == null) {
             result = conn.createNativeSchema().getEffectiveObjectClasses(
@@ -265,7 +264,7 @@ public class LdapSchemaMapping {
         }
     }
 
-    private Uid createUid(String ldapUidAttr, Attributes attributes) {
+    protected Uid createUid(String ldapUidAttr, Attributes attributes) {
         String value = getStringAttrValue(attributes, ldapUidAttr);
         if (value != null) {
             return new Uid(value);

--- a/src/main/java/net/tirasa/connid/bundles/ldap/search/DefaultSearchStrategy.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/search/DefaultSearchStrategy.java
@@ -40,7 +40,7 @@ public class DefaultSearchStrategy extends LdapSearchStrategy {
 
     private static final Log LOG = Log.getLog(DefaultSearchStrategy.class);
 
-    private final boolean ignoreNonExistingBaseDNs;
+    protected final boolean ignoreNonExistingBaseDNs;
 
     public DefaultSearchStrategy(boolean ignoreNonExistingBaseDNs) {
         this.ignoreNonExistingBaseDNs = ignoreNonExistingBaseDNs;

--- a/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapFilter.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapFilter.java
@@ -53,8 +53,8 @@ import org.identityconnectors.framework.common.objects.filter.EqualsFilter;
  */
 public final class LdapFilter {
 
-    private final String nativeFilter;
-    private final String entryDN;
+    protected final String nativeFilter;
+    protected final String entryDN;
 
     public static LdapFilter forEntryDN(String entryDN) {
         return new LdapFilter(null, entryDN);
@@ -64,7 +64,7 @@ public final class LdapFilter {
         return new LdapFilter(nativeFilter, null);
     }
 
-    private LdapFilter(String nativeFilter, String entryDN) {
+    protected LdapFilter(String nativeFilter, String entryDN) {
         this.nativeFilter = nativeFilter;
         this.entryDN = entryDN;
     }
@@ -126,7 +126,7 @@ public final class LdapFilter {
         return null;
     }
 
-    private static String combine(String left, String right, char op) {
+    protected static String combine(String left, String right, char op) {
         if (left != null) {
             if (right != null) {
                 StringBuilder builder = new StringBuilder();

--- a/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapFilterTranslator.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapFilterTranslator.java
@@ -41,7 +41,7 @@ import org.identityconnectors.framework.common.objects.filter.LessThanFilter;
 import org.identityconnectors.framework.common.objects.filter.LessThanOrEqualFilter;
 import org.identityconnectors.framework.common.objects.filter.SingleValueAttributeFilter;
 import org.identityconnectors.framework.common.objects.filter.StartsWithFilter;
-import net.tirasa.connid.bundles.ldap.schema.LdapSchemaMapping;
+import net.tirasa.connid.bundles.ldap.schema.LdapSchema;
 import org.identityconnectors.framework.common.objects.Attribute;
 import org.identityconnectors.framework.common.objects.AttributeBuilder;
 import org.identityconnectors.framework.common.objects.filter.EqualsIgnoreCaseFilter;
@@ -58,11 +58,11 @@ public class LdapFilterTranslator extends AbstractFilterTranslator<LdapFilter> {
     // seems incorrect. For an object not having an a attribute, (a <= X) will
     // be Undefined (cf. RFC 4511, section 4.5.1.7). But (a > X) would be Undefined
     // too, and so would be (!(a > X)).
-    protected final LdapSchemaMapping mapping;
+    protected final LdapSchema mapping;
 
     protected final ObjectClass objectClass;
 
-    public LdapFilterTranslator(LdapSchemaMapping mapping, ObjectClass objectClass) {
+    public LdapFilterTranslator(LdapSchema mapping, ObjectClass objectClass) {
         this.mapping = mapping;
         this.objectClass = objectClass;
     }

--- a/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapFilterTranslator.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapFilterTranslator.java
@@ -58,9 +58,9 @@ public class LdapFilterTranslator extends AbstractFilterTranslator<LdapFilter> {
     // seems incorrect. For an object not having an a attribute, (a <= X) will
     // be Undefined (cf. RFC 4511, section 4.5.1.7). But (a > X) would be Undefined
     // too, and so would be (!(a > X)).
-    private final LdapSchemaMapping mapping;
+    protected final LdapSchemaMapping mapping;
 
-    private final ObjectClass objectClass;
+    protected final ObjectClass objectClass;
 
     public LdapFilterTranslator(LdapSchemaMapping mapping, ObjectClass objectClass) {
         this.mapping = mapping;
@@ -177,7 +177,7 @@ public class LdapFilterTranslator extends AbstractFilterTranslator<LdapFilter> {
         return createContainsAllValuesFilter(filter, not);
     }
 
-    private LdapFilter createSingleValueFilter(String type, SingleValueAttributeFilter filter, boolean not) {
+    protected LdapFilter createSingleValueFilter(String type, SingleValueAttributeFilter filter, boolean not) {
         String attrName = mapping.getLdapAttribute(objectClass, filter.
                 getAttribute());
         if (attrName == null) {
@@ -193,7 +193,7 @@ public class LdapFilterTranslator extends AbstractFilterTranslator<LdapFilter> {
         return finishBuilder(builder);
     }
 
-    private void addSimpleFilter(String ldapAttr, String type, Object value, StringBuilder toBuilder) {
+    protected void addSimpleFilter(String ldapAttr, String type, Object value, StringBuilder toBuilder) {
         toBuilder.append(ldapAttr);
         toBuilder.append(type);
         if (!escapeAttrValue(value, toBuilder)) {
@@ -201,7 +201,7 @@ public class LdapFilterTranslator extends AbstractFilterTranslator<LdapFilter> {
         }
     }
 
-    private LdapFilter createContainsAllValuesFilter(AttributeFilter filter, boolean not) {
+    protected LdapFilter createContainsAllValuesFilter(AttributeFilter filter, boolean not) {
         String attrName = mapping.getLdapAttribute(objectClass, filter.
                 getAttribute());
         if (attrName == null) {
@@ -248,11 +248,11 @@ public class LdapFilterTranslator extends AbstractFilterTranslator<LdapFilter> {
         }
     }
 
-    private StringBuilder createBuilder(boolean not) {
+    protected StringBuilder createBuilder(boolean not) {
         return new StringBuilder(not ? "(!(" : "(");
     }
 
-    private LdapFilter finishBuilder(StringBuilder builder) {
+    protected LdapFilter finishBuilder(StringBuilder builder) {
         boolean not = builder.charAt(0) == '(' && builder.charAt(1) == '!';
         builder.append(not ? "))" : ")");
         return LdapFilter.forNativeFilter(builder.toString());

--- a/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapInternalSearch.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapInternalSearch.java
@@ -38,15 +38,15 @@ import org.identityconnectors.common.StringUtil;
  */
 public class LdapInternalSearch {
 
-    private final LdapConnection conn;
+    protected final LdapConnection conn;
 
-    private final String filter;
+    protected final String filter;
 
-    private final List<String> baseDNs;
+    protected final List<String> baseDNs;
 
-    private final LdapSearchStrategy strategy;
+    protected final LdapSearchStrategy strategy;
 
-    private final SearchControls controls;
+    protected final SearchControls controls;
 
     public LdapInternalSearch(
             final LdapConnection conn,

--- a/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapSearch.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapSearch.java
@@ -87,7 +87,7 @@ public class LdapSearch {
 
     public static Set<String> getAttributesReturnedByDefault(final LdapConnection conn, final ObjectClass oclass) {
         Set<String> result = CollectionUtil.newCaseInsensitiveSet();
-        ObjectClassInfo oci = conn.getSchemaMapping().schema().findObjectClassInfo(oclass.getObjectClassValue());
+        ObjectClassInfo oci = conn.getSchema().schema().findObjectClassInfo(oclass.getObjectClassValue());
         if (oci != null) {
             for (AttributeInfo info : oci.getAttributeInfo()) {
                 if (info.isReturnedByDefault()) {
@@ -230,7 +230,7 @@ public class LdapSearch {
 
         final boolean posixGroups = cleanAttrsToGet.remove(LdapConstants.POSIX_GROUPS_NAME);
 
-        final Set<String> result = conn.getSchemaMapping().getLdapAttributes(oclass, cleanAttrsToGet, true);
+        final Set<String> result = conn.getSchema().getLdapAttributes(oclass, cleanAttrsToGet, true);
 
         if (posixGroups) {
             result.add(GroupHelper.getPosixRefAttribute());
@@ -264,8 +264,8 @@ public class LdapSearch {
 
         final ConnectorObjectBuilder builder = new ConnectorObjectBuilder();
         builder.setObjectClass(oclass);
-        builder.setUid(conn.getSchemaMapping().createUid(oclass, entry));
-        builder.setName(conn.getSchemaMapping().createName(oclass, entry));
+        builder.setUid(conn.getSchema().createUid(oclass, entry));
+        builder.setName(conn.getSchema().createName(oclass, entry));
 
         final List<String> ldapGroups = new ArrayList<>();
         final List<String> posixGroups = new ArrayList<>();
@@ -288,7 +288,7 @@ public class LdapSearch {
 
                 attribute = AttributeBuilder.build(attrName, new GuardedString());
             } else {
-                attribute = conn.getSchemaMapping().createAttribute(oclass, attrName, entry, emptyAttrWhenNotFound);
+                attribute = conn.getSchema().createAttribute(oclass, attrName, entry, emptyAttrWhenNotFound);
             }
 
             if (attribute != null) {
@@ -336,7 +336,7 @@ public class LdapSearch {
 
     protected String getObjectClassFilter() {
         StringBuilder builder = new StringBuilder();
-        List<String> ldapClasses = conn.getSchemaMapping().getLdapClasses(oclass);
+        List<String> ldapClasses = conn.getSchema().getLdapClasses(oclass);
 
         boolean and = ldapClasses.size() > 1;
         if (and) {
@@ -437,12 +437,12 @@ public class LdapSearch {
 
     protected void removeNonReadableAttributes(final Set<String> attributes) {
         // Since the groups attributes are fake attributes, we don't want to
-        // send them to LdapSchemaMapping. This, for example, avoid an (unlikely)
+        // send them to LdapSchema. This, for example, avoid an (unlikely)
         // conflict with a custom attribute defined in the server schema.
         boolean ldapGroups = attributes.remove(LdapConstants.LDAP_GROUPS_NAME);
         boolean posixGroups = attributes.remove(LdapConstants.POSIX_GROUPS_NAME);
 
-        conn.getSchemaMapping().removeNonReadableAttributes(oclass, attributes);
+        conn.getSchema().removeNonReadableAttributes(oclass, attributes);
 
         if (ldapGroups) {
             attributes.add(LdapConstants.LDAP_GROUPS_NAME);

--- a/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapSearch.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapSearch.java
@@ -128,7 +128,7 @@ public class LdapSearch {
     /**
      * Performs the search and passes the resulting {@link ConnectorObject}s to the given handler.
      */
-    public final void execute() {
+    public void execute() {
         final String[] attrsToGetOption = options.getAttributesToGet();
         final Set<String> attrsToGet = getAttributesToGet(attrsToGetOption);
 
@@ -148,7 +148,7 @@ public class LdapSearch {
      *
      * @return the first {@link ConnectorObject} or {@code null}
      */
-    public final ConnectorObject getSingleResult() {
+    public ConnectorObject getSingleResult() {
         final String[] attrsToGetOption = options.getAttributesToGet();
         final Set<String> attrsToGet = getAttributesToGet(attrsToGetOption);
         final ConnectorObject[] results = new ConnectorObject[] { null };

--- a/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapSearch.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapSearch.java
@@ -71,19 +71,19 @@ public class LdapSearch {
 
     private static final Log LOG = Log.getLog(LdapSearch.class);
 
-    private final LdapConnection conn;
+    protected final LdapConnection conn;
 
-    private final ObjectClass oclass;
+    protected final ObjectClass oclass;
 
-    private final LdapFilter filter;
+    protected final LdapFilter filter;
 
-    private final OperationOptions options;
+    protected final OperationOptions options;
 
-    private final GroupHelper groupHelper;
+    protected final GroupHelper groupHelper;
 
-    private final String[] baseDNs;
+    protected final String[] baseDNs;
 
-    private final ResultsHandler handler;
+    protected final ResultsHandler handler;
 
     public static Set<String> getAttributesReturnedByDefault(final LdapConnection conn, final ObjectClass oclass) {
         Set<String> result = CollectionUtil.newCaseInsensitiveSet();
@@ -167,7 +167,7 @@ public class LdapSearch {
         return results[0];
     }
 
-    private LdapInternalSearch getInternalSearch(final Set<String> attrsToGet) {
+    protected LdapInternalSearch getInternalSearch(final Set<String> attrsToGet) {
         // This is a bit tricky. If the LdapFilter has an entry DN,
         // we only need to look at that entry and check whether it matches
         // the native filter. Moreover, when looking at the entry DN
@@ -222,7 +222,7 @@ public class LdapSearch {
                 dns, strategy, controls);
     }
 
-    private Set<String> getLdapAttributesToGet(final Set<String> attrsToGet) {
+    protected Set<String> getLdapAttributesToGet(final Set<String> attrsToGet) {
         final Set<String> cleanAttrsToGet = CollectionUtil.newCaseInsensitiveSet();
 
         cleanAttrsToGet.addAll(attrsToGet);
@@ -254,7 +254,7 @@ public class LdapSearch {
      * baseDN} parameter is needed in order to create the whole entry DN, which is used to compute the connector
      * object's name attribute.
      */
-    private ConnectorObject createConnectorObject(
+    protected ConnectorObject createConnectorObject(
             final String baseDN,
             final SearchResult result,
             final Set<String> attrsToGet,
@@ -308,7 +308,7 @@ public class LdapSearch {
      * filter to be applied before the object class filters, the filters for all LDAP object classes for the given
      * {@code ObjectClass}, and an optional filter to be applied before the object class filters.
      */
-    private String getSearchFilter(final String... optionalFilters) {
+    protected String getSearchFilter(final String... optionalFilters) {
         StringBuilder builder = new StringBuilder();
         String ocFilter = getObjectClassFilter();
         int nonBlank = StringUtil.isBlank(ocFilter) ? 0 : 1;
@@ -334,7 +334,7 @@ public class LdapSearch {
         return builder.toString();
     }
 
-    private String getObjectClassFilter() {
+    protected String getObjectClassFilter() {
         StringBuilder builder = new StringBuilder();
         List<String> ldapClasses = conn.getSchemaMapping().getLdapClasses(oclass);
 
@@ -356,7 +356,7 @@ public class LdapSearch {
         return builder.toString();
     }
 
-    private static void appendFilter(String filter, StringBuilder toBuilder) {
+    protected static void appendFilter(String filter, StringBuilder toBuilder) {
         if (!StringUtil.isBlank(filter)) {
             final String trimmedUserFilter = filter.trim();
             final boolean enclose = filter.charAt(0) != '(';
@@ -373,7 +373,7 @@ public class LdapSearch {
         }
     }
 
-    private List<String> getBaseDNs() {
+    protected List<String> getBaseDNs() {
         List<String> result;
 
         final QualifiedUid container = options.getContainer();
@@ -389,7 +389,7 @@ public class LdapSearch {
         return result;
     }
 
-    private LdapSearchStrategy getSearchStrategy() {
+    protected LdapSearchStrategy getSearchStrategy() {
         LdapSearchStrategy result = conn.getConfiguration().newDefaultSearchStrategy(false);
         if (options.getPageSize() != null) {
             if (conn.getConfiguration().isUseVlvControls() && conn.supportsControl(VirtualListViewControl.OID)) {
@@ -409,7 +409,7 @@ public class LdapSearch {
         return result;
     }
 
-    private Set<String> getAttributesToGet(final String[] attributesToGet) {
+    protected Set<String> getAttributesToGet(final String[] attributesToGet) {
         Set<String> result;
 
         if (attributesToGet != null) {
@@ -435,7 +435,7 @@ public class LdapSearch {
         return result;
     }
 
-    private void removeNonReadableAttributes(final Set<String> attributes) {
+    protected void removeNonReadableAttributes(final Set<String> attributes) {
         // Since the groups attributes are fake attributes, we don't want to
         // send them to LdapSchemaMapping. This, for example, avoid an (unlikely)
         // conflict with a custom attribute defined in the server schema.
@@ -453,7 +453,7 @@ public class LdapSearch {
         }
     }
 
-    private int getLdapSearchScope(boolean ignoreUserAnyObjectConfig) {
+    protected int getLdapSearchScope(boolean ignoreUserAnyObjectConfig) {
         String scope = options.getScope();
 
         if (scope == null) {

--- a/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapSearchStrategy.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapSearchStrategy.java
@@ -40,7 +40,7 @@ public abstract class LdapSearchStrategy {
             final LdapSearchResultsHandler handler)
             throws IOException, NamingException;
 
-    static String searchControlsToString(final SearchControls controls) {
+    protected static String searchControlsToString(final SearchControls controls) {
         StringBuilder builder = new StringBuilder();
 
         builder.append("SearchControls: {returningAttributes=");

--- a/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapSearches.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapSearches.java
@@ -113,7 +113,7 @@ public final class LdapSearches {
         LdapFilter ldapFilter;
 
         // If the Uid is actually the entry DN, we do not need to do a search do find the entry DN.
-        String uidAttr = conn.getSchemaMapping().getLdapUidAttribute(oclass);
+        String uidAttr = conn.getSchema().getLdapUidAttribute(oclass);
         if (LdapEntry.isDNAttribute(uidAttr)) {
             if (check) {
                 // We'll do a search in order to check that the entry with that DN exists.
@@ -125,7 +125,7 @@ public final class LdapSearches {
             }
         } else {
             EqualsFilter filter = (EqualsFilter) FilterBuilder.equalTo(uid);
-            ldapFilter = new LdapFilterTranslator(conn.getSchemaMapping(), oclass).
+            ldapFilter = new LdapFilterTranslator(conn.getSchema(), oclass).
                     createEqualsExpression(filter, false);
         }
         assert ldapFilter != null;
@@ -151,7 +151,7 @@ public final class LdapSearches {
         final List<ConnectorObject> result = new ArrayList<>();
 
         EqualsFilter filter = (EqualsFilter) FilterBuilder.equalTo(attr);
-        LdapFilter ldapFilter = new LdapFilterTranslator(conn.getSchemaMapping(), oclass).
+        LdapFilter ldapFilter = new LdapFilterTranslator(conn.getSchema(), oclass).
                 createEqualsExpression(filter, false);
 
         OperationOptionsBuilder builder = new OperationOptionsBuilder();

--- a/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapSearches.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/search/LdapSearches.java
@@ -101,7 +101,7 @@ public final class LdapSearches {
      * the method will throw a <code>UnknownUidException</code> if the entry identified
      * by the Uid does not exist.
      */
-    private static String findEntryDN(
+    protected static String findEntryDN(
             LdapConnection conn,
             ObjectClass oclass,
             Uid uid,

--- a/src/main/java/net/tirasa/connid/bundles/ldap/search/PagedSearchStrategy.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/search/PagedSearchStrategy.java
@@ -47,15 +47,15 @@ public class PagedSearchStrategy extends LdapSearchStrategy {
 
     private static final Log LOG = Log.getLog(PagedSearchStrategy.class);
 
-    private final int pageSize;
+    protected final int pageSize;
 
-    private final int pagedResultsOffset;
+    protected final int pagedResultsOffset;
 
-    private final String pagedResultsCookie;
+    protected final String pagedResultsCookie;
 
-    private final SearchResultsHandler searchResultHandler;
+    protected final SearchResultsHandler searchResultHandler;
 
-    private final SortKey[] sortKeys;
+    protected final SortKey[] sortKeys;
 
     public PagedSearchStrategy(final int pageSize, final String pagedResultsCookie, final Integer pagedResultsOffset,
             final SearchResultsHandler searchResultHandler, final SortKey[] sortKeys) {
@@ -169,7 +169,7 @@ public class PagedSearchStrategy extends LdapSearchStrategy {
         }
     }
 
-    private PagedResultsResponseControl getPagedControl(final Control[] controls) {
+    protected PagedResultsResponseControl getPagedControl(final Control[] controls) {
         if (controls != null) {
             for (Control control : controls) {
                 if (control instanceof PagedResultsResponseControl) {

--- a/src/main/java/net/tirasa/connid/bundles/ldap/sync/sunds/SunDSChangeLogSyncStrategy.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/sync/sunds/SunDSChangeLogSyncStrategy.java
@@ -223,7 +223,7 @@ public class SunDSChangeLogSyncStrategy implements LdapSyncStrategy {
             LOG.ok("Creating sync delta for deleted entry " + getStringAttrValue(changeLogEntry.getAttributes(),
                     "targetEntryUUID"));
 
-            String uidAttr = conn.getSchemaMapping().getLdapUidAttribute(oclass);
+            String uidAttr = conn.getSchema().getLdapUidAttribute(oclass);
 
             Uid deletedUid;
             if (LDAP_DN_ATTRIBUTES.contains(uidAttr)) {
@@ -357,12 +357,12 @@ public class SunDSChangeLogSyncStrategy implements LdapSyncStrategy {
         LOG.ok("Creating sync delta for created or updated entry");
 
         if ("modrdn".equalsIgnoreCase(changeType)) {
-            String uidAttr = conn.getSchemaMapping().getLdapUidAttribute(oclass);
+            String uidAttr = conn.getSchema().getLdapUidAttribute(oclass);
 
             // We can only set the previous Uid if it is the entry DN, 
             // which is readily available.
             if (LdapEntry.isDNAttribute(uidAttr)) {
-                syncDeltaBuilder.setPreviousUid(conn.getSchemaMapping().createUid(oclass, targetDN));
+                syncDeltaBuilder.setPreviousUid(conn.getSchema().createUid(oclass, targetDN));
             }
         }
 

--- a/src/test/java/net/tirasa/connid/bundles/ldap/AdapterCompatibilityTests.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/AdapterCompatibilityTests.java
@@ -52,7 +52,7 @@ import org.identityconnectors.framework.common.objects.OperationalAttributes;
 import org.identityconnectors.framework.common.objects.Uid;
 import org.identityconnectors.framework.common.objects.filter.Filter;
 import org.identityconnectors.framework.common.objects.filter.FilterBuilder;
-import net.tirasa.connid.bundles.ldap.schema.LdapSchemaMapping;
+import net.tirasa.connid.bundles.ldap.schema.LdapSchema;
 import org.identityconnectors.test.common.TestHelpers;
 import net.tirasa.connid.bundles.ldap.commons.LdapConstants;
 import net.tirasa.connid.bundles.ldap.commons.LdapUtil;
@@ -589,10 +589,10 @@ public class AdapterCompatibilityTests extends LdapConnectorTestBase {
         OperationOptionsBuilder builder = new OperationOptionsBuilder();
         builder.setAttributesToGet("cn", "dn");
         List<ConnectorObject> objects = TestHelpers.searchToList(
-                facade, LdapSchemaMapping.ANY_OBJECT_CLASS, filter, builder.build());
+                facade, LdapSchema.ANY_OBJECT_CLASS, filter, builder.build());
 
         ConnectorObject bunny = objects.get(0);
-        assertEquals(LdapSchemaMapping.ANY_OBJECT_CLASS, bunny.getObjectClass());
+        assertEquals(LdapSchema.ANY_OBJECT_CLASS, bunny.getObjectClass());
         assertEquals(BUGS_BUNNY_DN, bunny.getName().getNameValue());
         assertEquals(BUGS_BUNNY_CN, bunny.getAttributeByName("cn").getValue().get(0));
     }

--- a/src/test/java/net/tirasa/connid/bundles/ldap/LdapConnectorTestBase.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/LdapConnectorTestBase.java
@@ -185,6 +185,7 @@ public abstract class LdapConnectorTestBase {
         config.setPrincipal(ADMIN_DN);
         config.setCredentials(ADMIN_PASSWORD);
         config.setReadSchema(readSchema);
+        config.validate();
         return config;
     }
 

--- a/src/test/java/net/tirasa/connid/bundles/ldap/modify/LdapCreateTests.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/modify/LdapCreateTests.java
@@ -46,7 +46,7 @@ import org.identityconnectors.framework.common.objects.Uid;
 import net.tirasa.connid.bundles.ldap.LdapConfiguration;
 import net.tirasa.connid.bundles.ldap.LdapConnectorTestBase;
 import net.tirasa.connid.bundles.ldap.MyStatusManagement;
-import net.tirasa.connid.bundles.ldap.schema.LdapSchemaMapping;
+import net.tirasa.connid.bundles.ldap.schema.LdapSchema;
 
 import org.identityconnectors.framework.common.objects.OperationOptions;
 import org.junit.jupiter.api.Test;
@@ -168,7 +168,7 @@ public class LdapCreateTests extends LdapConnectorTestBase {
         ConnectorFacade facade = newFacade(config);
 
         ConnectorObject created = doCreateArbitrary(facade);
-        facade.delete(LdapSchemaMapping.ANY_OBJECT_CLASS, created.getUid(), null);
+        facade.delete(LdapSchema.ANY_OBJECT_CLASS, created.getUid(), null);
     }
 
     @Test
@@ -179,7 +179,7 @@ public class LdapCreateTests extends LdapConnectorTestBase {
         ConnectorFacade facade = newFacade(config);
 
         ConnectorObject created = doCreateArbitrary(facade);
-        facade.delete(LdapSchemaMapping.ANY_OBJECT_CLASS, created.getUid(), null);
+        facade.delete(LdapSchema.ANY_OBJECT_CLASS, created.getUid(), null);
     }
 
     @Test
@@ -195,7 +195,7 @@ public class LdapCreateTests extends LdapConnectorTestBase {
         ConnectorFacade facade = newFacade(config);
 
         ConnectorObject created = doCreateArbitrary(facade);
-        facade.delete(LdapSchemaMapping.ANY_OBJECT_CLASS, created.getUid(), null);
+        facade.delete(LdapSchema.ANY_OBJECT_CLASS, created.getUid(), null);
     }
 
     private ConnectorObject doCreateArbitrary(ConnectorFacade facade) {
@@ -204,9 +204,9 @@ public class LdapCreateTests extends LdapConnectorTestBase {
         Name name = new Name("o=Smallest," + SMALL_COMPANY_DN);
         attributes.add(name);
         attributes.add(AttributeBuilder.build("o", "Smallest"));
-        Uid uid = facade.create(LdapSchemaMapping.ANY_OBJECT_CLASS, attributes, null);
+        Uid uid = facade.create(LdapSchema.ANY_OBJECT_CLASS, attributes, null);
 
-        ConnectorObject newObject = facade.getObject(LdapSchemaMapping.ANY_OBJECT_CLASS, uid, null);
+        ConnectorObject newObject = facade.getObject(LdapSchema.ANY_OBJECT_CLASS, uid, null);
         assertEquals(name, newObject.getName());
         return newObject;
     }
@@ -221,7 +221,7 @@ public class LdapCreateTests extends LdapConnectorTestBase {
         ConnectorFacade facade = newFacade(config);
 
         ConnectorObject created = doCreateDevice(facade);
-        facade.delete(LdapSchemaMapping.ANY_OBJECT_CLASS, created.getUid(), null);
+        facade.delete(LdapSchema.ANY_OBJECT_CLASS, created.getUid(), null);
     }
 
     @Test
@@ -233,7 +233,7 @@ public class LdapCreateTests extends LdapConnectorTestBase {
         ConnectorFacade facade = newFacade(config);
 
         ConnectorObject created = doCreateDevice(facade);
-        facade.delete(LdapSchemaMapping.ANY_OBJECT_CLASS, created.getUid(), null);
+        facade.delete(LdapSchema.ANY_OBJECT_CLASS, created.getUid(), null);
     }
 
     private ConnectorObject doCreateDevice(ConnectorFacade facade) {
@@ -243,9 +243,9 @@ public class LdapCreateTests extends LdapConnectorTestBase {
         attributes.add(AttributeBuilder.build("cn", DEVICE_0_CN));
         attributes.add(AttributeBuilder.build("serialNumber", DEVICE_0_SERIALNUMBER));
 
-        Uid uid = facade.create(LdapSchemaMapping.ANY_OBJECT_CLASS, attributes, null);
+        Uid uid = facade.create(LdapSchema.ANY_OBJECT_CLASS, attributes, null);
 
-        ConnectorObject newObject = facade.getObject(LdapSchemaMapping.ANY_OBJECT_CLASS, uid, null);
+        ConnectorObject newObject = facade.getObject(LdapSchema.ANY_OBJECT_CLASS, uid, null);
         assertEquals(name, newObject.getName());
         return newObject;
     }

--- a/src/test/java/net/tirasa/connid/bundles/ldap/search/LdapFilterTranslatorTests.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/search/LdapFilterTranslatorTests.java
@@ -43,7 +43,7 @@ import org.identityconnectors.framework.common.objects.filter.StartsWithFilter;
 import net.tirasa.connid.bundles.ldap.LdapConfiguration;
 import net.tirasa.connid.bundles.ldap.LdapConnection;
 import net.tirasa.connid.bundles.ldap.LdapConnectorTestBase;
-import net.tirasa.connid.bundles.ldap.schema.LdapSchemaMapping;
+import net.tirasa.connid.bundles.ldap.schema.LdapSchema;
 import org.identityconnectors.framework.common.objects.filter.EqualsIgnoreCaseFilter;
 import org.junit.jupiter.api.Test;
 
@@ -198,6 +198,6 @@ public class LdapFilterTranslatorTests extends LdapConnectorTestBase {
     private static LdapFilterTranslator newTranslator() {
         LdapConfiguration config = LdapConnectorTestBase.newConfiguration();
         LdapConnection conn = new LdapConnection(config);
-        return new LdapFilterTranslator(new LdapSchemaMapping(conn), ObjectClass.ACCOUNT);
+        return new LdapFilterTranslator(new LdapSchema(conn), ObjectClass.ACCOUNT);
     }
 }

--- a/src/test/java/net/tirasa/connid/bundles/ldap/search/LdapSearchTests.java
+++ b/src/test/java/net/tirasa/connid/bundles/ldap/search/LdapSearchTests.java
@@ -54,7 +54,7 @@ import org.identityconnectors.framework.common.objects.filter.FilterBuilder;
 import net.tirasa.connid.bundles.ldap.LdapConfiguration;
 import net.tirasa.connid.bundles.ldap.LdapConnection;
 import net.tirasa.connid.bundles.ldap.LdapConnectorTestBase;
-import net.tirasa.connid.bundles.ldap.schema.LdapSchemaMapping;
+import net.tirasa.connid.bundles.ldap.schema.LdapSchema;
 
 import org.identityconnectors.common.CollectionUtil;
 import org.identityconnectors.framework.common.objects.SearchResult;
@@ -432,7 +432,7 @@ public class LdapSearchTests extends LdapConnectorTestBase {
 
         // We can get the 'carrot laptop' device with an 'object' search by DN
         ConnectorObject carrotLaptop = searchByAttribute(
-                facade, LdapSchemaMapping.ANY_OBJECT_CLASS, new Name(CARROT_LAPTOP_DN));
+                facade, LdapSchema.ANY_OBJECT_CLASS, new Name(CARROT_LAPTOP_DN));
         assertNotNull(carrotLaptop);
 
         // Reconfigure for 'onelevel' search
@@ -442,7 +442,7 @@ public class LdapSearchTests extends LdapConnectorTestBase {
 
         // 'carrot laptop'' doesn't exist directly under the organisation..
         List<ConnectorObject> objects = TestHelpers.searchToList(
-                facade, LdapSchemaMapping.ANY_OBJECT_CLASS, null, options);
+                facade, LdapSchema.ANY_OBJECT_CLASS, null, options);
         assertTrue(objects.isEmpty());
 
         // Reconfigure for 'subtree' search
@@ -450,7 +450,7 @@ public class LdapSearchTests extends LdapConnectorTestBase {
         facade = newFacade(configuration);
 
         // ... but does in the organisation subtree
-        objects = TestHelpers.searchToList(facade, LdapSchemaMapping.ANY_OBJECT_CLASS, null, options);
+        objects = TestHelpers.searchToList(facade, LdapSchema.ANY_OBJECT_CLASS, null, options);
         assertFalse(objects.isEmpty());
     }
 
@@ -561,7 +561,7 @@ public class LdapSearchTests extends LdapConnectorTestBase {
         configuration.setAnyObjectNameAttributes("cn");
         facade = newFacade(configuration);
         List<ConnectorObject> objects = TestHelpers.searchToList(
-                facade, LdapSchemaMapping.ANY_OBJECT_CLASS, null, optionsBuilder.build());
+                facade, LdapSchema.ANY_OBJECT_CLASS, null, optionsBuilder.build());
         assertNotNull(getObjectByName(objects, CARROT_LAPTOP_DN));
 
         // Test the anyObject search filter
@@ -569,7 +569,7 @@ public class LdapSearchTests extends LdapConnectorTestBase {
         configuration.setAnyObjectSearchFilter("(cn=" + CARROT_LAPTOP_CN + ")");
         configuration.setAnyObjectClasses("top", "device");
         facade = newFacade(configuration);
-        objects = TestHelpers.searchToList(facade, LdapSchemaMapping.ANY_OBJECT_CLASS, null, optionsBuilder.build());
+        objects = TestHelpers.searchToList(facade, LdapSchema.ANY_OBJECT_CLASS, null, optionsBuilder.build());
         assertEquals(1, objects.size());
         assertNotNull(getObjectByName(objects, CARROT_LAPTOP_DN));
     }
@@ -593,7 +593,7 @@ public class LdapSearchTests extends LdapConnectorTestBase {
         ConnectorFacade facade = newFacade(config);
 
         // If parentheses were not added, the search would fail.
-        assertNotNull(searchByAttribute(facade, LdapSchemaMapping.ANY_OBJECT_CLASS, new Name(CARROT_LAPTOP_DN)));
+        assertNotNull(searchByAttribute(facade, LdapSchema.ANY_OBJECT_CLASS, new Name(CARROT_LAPTOP_DN)));
     }
 
     @Test


### PR DESCRIPTION
Currently, the AD bundle repeats quite a bit of code, and only in some places inherits from this LDAP bundle. 

As AD is fundamentally communicated with via LDAP, the AD bundle should inherit most of it’s functionality from the LDAP bundle, therefore inheriting LDAP capabilities, and just extending classes/overriding methods where necessary.

This issue is for part 1 of sorting this - the preparation of the LDAP bundle.

This PR is a precondition for https://github.com/Tirasa/ConnIdADBundle/pull/18