### PR TITLE
[LDAP-41] Sync strategy hotfixes

### DIFF
--- a/src/main/java/net/tirasa/connid/bundles/ldap/LdapConnector.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/LdapConnector.java
@@ -87,6 +87,7 @@ public class LdapConnector implements
     @Override
     public void init(Configuration cfg) {
         config = (LdapConfiguration) cfg;
+        config.validate();
         Class<? extends LdapSyncStrategy> syncStrategyClass = config.getSyncStrategyClass();
         Class<? extends LdapConnection> connectionClass = config.getConnectionClass();
         

--- a/src/main/java/net/tirasa/connid/bundles/ldap/sync/GenericChangeLogSyncStrategy.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/sync/GenericChangeLogSyncStrategy.java
@@ -133,7 +133,7 @@ public class GenericChangeLogSyncStrategy implements LdapSyncStrategy {
             return true;
         });
 
-        return new SyncToken(maxChangeNumber);
+        return new SyncToken(maxChangeNumber[0]);
     }
 
     @Override


### PR DESCRIPTION
Fix a bug in the generic change log sync strategy failing to get the latest sync token.
Fix a bug where the sync strategy class is not necessarily yet defined due to the config not being validated prior to usage