### PR TITLE
[LDAP-49] Fix: Delta delete not propagating

### DIFF
--- a/src/main/java/net/tirasa/connid/bundles/ldap/sync/GenericChangeLogSyncStrategy.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/sync/GenericChangeLogSyncStrategy.java
@@ -473,7 +473,7 @@ public class GenericChangeLogSyncStrategy implements LdapSyncStrategy {
         ConnectorObjectBuilder objectBuilder = new ConnectorObjectBuilder();
         objectBuilder.setObjectClass(oclass);
         objectBuilder.setUid(deletedUid);
-        objectBuilder.setName("fake-dn");
+        objectBuilder.setName(targetDN);
         objectBuilder.addAttributes(Collections.<Attribute>emptySet());
 
         syncDeltaBuilder.setUid(deletedUid);

--- a/src/main/java/net/tirasa/connid/bundles/ldap/sync/sunds/SunDSChangeLogSyncStrategy.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/sync/sunds/SunDSChangeLogSyncStrategy.java
@@ -83,7 +83,7 @@ public class SunDSChangeLogSyncStrategy extends GenericChangeLogSyncStrategy {
         ConnectorObjectBuilder objectBuilder = new ConnectorObjectBuilder();
         objectBuilder.setObjectClass(oclass);
         objectBuilder.setUid(deletedUid);
-        objectBuilder.setName("fake-dn");
+        objectBuilder.setName(targetDN);
         objectBuilder.addAttributes(Collections.<Attribute>emptySet());
 
         syncDeltaBuilder.setUid(deletedUid);


### PR DESCRIPTION
Update setName to targetDN instead of "fake-dn" such that the delete delta links up correctly to previously pulled resource